### PR TITLE
Add github action to publish to test.pypi

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -61,7 +61,9 @@ jobs:
 
       - name: Build source distribution
         if: matrix.os == 'ubuntu-latest'
-        run: python setup.py sdist
+        run: |
+          python setup.py sdist
+          twine upload --skip-existing dist/*.tar.gz
 
       - name: Build manylinux Python wheels
         if: matrix.os == 'ubuntu-latest'
@@ -73,4 +75,4 @@ jobs:
           pre-build-command: 'export CFLAGS=-I/usr/include/udunits2'
 
       - name: Upload distributions
-        run: twine upload --skip-existing dist/(*-${{ matrix.platform }}*.whl|*.tar.gz)
+        run: twine upload --skip-existing dist/*-${{ matrix.platform }}*.whl

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -29,8 +29,7 @@ jobs:
             wheels: '*-win*.whl'
         exclude:
           -os: ubuntu-latest
-           python-version: 3.7
-           python-version: 3.9
+           python-version: [3.7, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -48,16 +48,15 @@ jobs:
           conda info
           conda list
 
-      - name: Install requirements
-        run: |
-          conda install mamba
-          mamba install --file=requirements.txt udunits2
-          pip install twine wheel cython
-          mamba list
+      - name: Install build environment
+        run: pip install twine wheel cython
 
       - name: Build macosx/win Python wheels
         if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
-        run: python setup.py bdist_wheel
+        run: |
+          conda install mamba
+          mamba install --file=requirements.txt udunits2
+          python setup.py bdist_wheel
 
       - name: Build source distribution
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -38,7 +38,7 @@ jobs:
           mamba list
 
       - name: Install pypa/build
-        run: pip install build
+        run: pip install build cython
 
       - name: Build a binary wheel and a source tarball
         run: python -m build --no-isolation --sdist --wheel --outdir dist/ .

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -42,11 +42,13 @@ jobs:
         if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
         run: |
           python setup.py bdist_wheel
+          twine upload --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} dist/*gimli* --repository-url=https://test.pypi.org/legacy/
 
       - name: Build source distribution
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
         run: |
           python setup.py sdist
+          twine upload --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} dist/*gimli* --repository-url=https://test.pypi.org/legacy/
 
       - name: Build manylinux Python wheels
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
@@ -55,7 +57,5 @@ jobs:
           python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
           build-requirements: 'cython numpy'
           system-packages: 'udunits2-devel'
-
-      - name: Publish wheels to PyPI
         run: |
           twine upload --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} dist/*gimli* --repository-url=https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]
 
     steps:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -66,4 +66,4 @@ jobs:
       - name: Upload manylinux distributions
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
         run: |
-          twine upload --skip-existing dist/*gimli* --repository-url=https://test.pypi.org/legacy/
+          twine upload --skip-existing dist/*-manylinux*.whl --repository-url=https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -49,7 +49,7 @@ jobs:
           conda list
 
       - name: Install build environment
-        run: pip install twine wheel cython
+        run: pip install twine wheel numpy cython
 
       - name: Build macosx/win Python wheels
         if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]
 
     steps:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,44 +7,44 @@ jobs:
     name: Build and publish to PyPI
     runs-on: ${{ matrix.os }}
 
-  defaults:
-    run:
-      shell: bash -l {0}
+    defaults:
+      run:
+        shell: bash -l {0}
 
-  strategy:
-    matrix:
-      os: [ubuntu-latest, macos-latest, windows-latest]
-      python-version: [3.7, 3.8, 3.9]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9]
 
-  steps:
-    - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        auto-update-conda: true
-        python-version: ${{ matrix.python-version }}
-        channels: conda-forge
-        channel-priority: true
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          channel-priority: true
 
-    - name: Show conda installation info
-      run: |
-        conda info
-        conda list
+      - name: Show conda installation info
+        run: |
+          conda info
+          conda list
 
-    - name: Install requirements
-      run: |
-        conda install mamba
-        mamba install --file=requirements.txt udunits2
-        mamba list
+      - name: Install requirements
+        run: |
+          conda install mamba
+          mamba install --file=requirements.txt udunits2
+          mamba list
 
-    - name: Install pypa/build
-      run: python -m pip install build
+      - name: Install pypa/build
+        run: python -m pip install build
 
-    - name: Build a binary wheel and a source tarball
-      run: python -m build --sdist --wheel --outdir dist/ .
+      - name: Build a binary wheel and a source tarball
+        run: python -m build --sdist --wheel --outdir dist/ .
 
-    - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -73,4 +73,4 @@ jobs:
           pre-build-command: 'export CFLAGS=-I/usr/include/udunits2'
 
       - name: Upload distributions
-        run: twine upload --skip-existing dist/*-${{ matrix.platform }}*.whl
+        run: twine upload --skip-existing dist/(*-${{ matrix.platform }}*.whl|*.tar.gz)

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -28,10 +28,8 @@ jobs:
           - os: windows-latest
             wheels: '*-win*.whl'
         exclude:
-          -os: ubuntu-latest
-           python-version: 3.7
-          -os: ubuntu-latest
-           python-version: 3.9
+          - os: ubuntu-latest
+            python-version: [3.7, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -29,7 +29,9 @@ jobs:
             wheels: '*-win*.whl'
         exclude:
           -os: ubuntu-latest
-           python-version: [3.7, 3.9]
+           python-version: 3.7
+          -os: ubuntu-latest
+           python-version: 3.9
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,11 +22,11 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
         include:
           - os: ubuntu-latest
-            wheels: '(*-manylinux*.whl|*.tar.gz)'
+            platform: manylinux
           - os: macos-latest
-            wheels: '*-macosx*.whl'
+            platform: macosx
           - os: windows-latest
-            wheels: '*-win*.whl'
+            platform: win
         exclude:
           - os: ubuntu-latest
             python-version: 3.7
@@ -73,8 +73,4 @@ jobs:
           pre-build-command: 'export CFLAGS=-I/usr/include/udunits2'
 
       - name: Upload distributions
-        run: >-
-          twine
-          upload
-          --skip-existing
-          dist/${{ matrix.wheels }}
+        run: twine upload --skip-existing dist/*-${{ matrix.platform }}*.whl

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -35,10 +35,27 @@ jobs:
         run: |
           conda install mamba
           mamba install --file=requirements.txt udunits2
+          pip install twine wheel cython
           mamba list
 
-      - name: Install pypa/build
+      - name: Build macosx/win Python wheels
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
         run: |
-          pip install twine wheel cython
           python setup.py bdist_wheel
+
+      - name: Build source distribution
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+        run: |
+          python setup.py sdist
+
+      - name: Build manylinux Python wheels
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+        uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
+        with:
+          python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
+          build-requirements: 'cython numpy'
+          system-packages: 'udunits2-devel'
+
+      - name: Publish wheels to PyPI
+        run: |
           twine upload --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} dist/*gimli* --repository-url=https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -38,13 +38,7 @@ jobs:
           mamba list
 
       - name: Install pypa/build
-        run: pip install build cython
-
-      - name: Build a binary wheel and a source tarball
-        run: python -m build --no-isolation --sdist --wheel --outdir dist/ .
-
-      - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+        run: |
+          pip install twine wheel cython
+          python setup.py bdist_wheel
+          twine upload -u mcflugen -p${{ secrets.TEST_PYPI_API_TOKEN }} dist/*gimli* --repository-url=https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -29,7 +29,9 @@ jobs:
             wheels: '*-win*.whl'
         exclude:
           - os: ubuntu-latest
-            python-version: [3.7, 3.9]
+            python-version: 3.7
+          - os: ubuntu-latest
+            python-version: 3.9
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -41,4 +41,4 @@ jobs:
         run: |
           pip install twine wheel cython
           python setup.py bdist_wheel
-          twine upload -u mcflugen -p${{ secrets.TEST_PYPI_API_TOKEN }} dist/*gimli* --repository-url=https://test.pypi.org/legacy/
+          twine upload --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} dist/*gimli* --repository-url=https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,50 @@
+name: PyPI
+
+on: [push]
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ${{ matrix.os }}
+
+  defaults:
+    run:
+      shell: bash -l {0}
+
+  strategy:
+    matrix:
+      os: [ubuntu-latest, macos-latest, windows-latest]
+      python-version: [3.7, 3.8, 3.9]
+
+  steps:
+    - uses: actions/checkout@v2
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
+        channels: conda-forge
+        channel-priority: true
+
+    - name: Show conda installation info
+      run: |
+        conda info
+        conda list
+
+    - name: Install requirements
+      run: |
+        conda install mamba
+        mamba install --file=requirements.txt udunits2
+        mamba list
+
+    - name: Install pypa/build
+      run: python -m pip install build
+
+    - name: Build a binary wheel and a source tarball
+      run: python -m build --sdist --wheel --outdir dist/ .
+
+    - name: Publish distribution to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -38,10 +38,10 @@ jobs:
           mamba list
 
       - name: Install pypa/build
-        run: python -m pip install build
+        run: pip install build
 
       - name: Build a binary wheel and a source tarball
-        run: python -m build --sdist --wheel --outdir dist/ .
+        run: python -m build --no-isolation --sdist --wheel --outdir dist/ .
 
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,6 +2,10 @@ name: PyPI
 
 on: [push]
 
+env:
+  TWINE_USERNAME: __token__
+  TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+
 jobs:
   build-and-publish:
     name: Build and publish to PyPI
@@ -42,13 +46,13 @@ jobs:
         if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
         run: |
           python setup.py bdist_wheel
-          twine upload --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} dist/*gimli* --repository-url=https://test.pypi.org/legacy/
+          twine upload --skip-existing dist/*gimli* --repository-url=https://test.pypi.org/legacy/
 
       - name: Build source distribution
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
         run: |
           python setup.py sdist
-          twine upload --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} dist/*gimli* --repository-url=https://test.pypi.org/legacy/
+          twine upload --skip-existing dist/*gimli* --repository-url=https://test.pypi.org/legacy/
 
       - name: Build manylinux Python wheels
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
@@ -57,8 +61,9 @@ jobs:
           python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
           build-requirements: 'cython numpy'
           system-packages: 'udunits2-devel'
+          pre-build-command: 'export CFLAGS=-I/usr/include/udunits2'
 
       - name: Upload manylinux distributions
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
         run: |
-          twine upload --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} dist/*gimli* --repository-url=https://test.pypi.org/legacy/
+          twine upload --skip-existing dist/*gimli* --repository-url=https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -57,5 +57,8 @@ jobs:
           python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
           build-requirements: 'cython numpy'
           system-packages: 'udunits2-devel'
+
+      - name: Upload manylinux distributions
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
         run: |
           twine upload --skip-existing -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} dist/*gimli* --repository-url=https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -20,6 +20,17 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]
+        include:
+          - os: ubuntu-latest
+            wheels: '(*-manylinux*.whl|*.tar.gz)'
+          - os: macos-latest
+            wheels: '*-macosx*.whl'
+          - os: windows-latest
+            wheels: '*-win*.whl'
+        exclude:
+          -os: ubuntu-latest
+           python-version: 3.7
+           python-version: 3.9
 
     steps:
       - uses: actions/checkout@v2
@@ -48,11 +59,11 @@ jobs:
         run: python setup.py bdist_wheel
 
       - name: Build source distribution
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+        if: matrix.os == 'ubuntu-latest'
         run: python setup.py sdist
 
       - name: Build manylinux Python wheels
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+        if: matrix.os == 'ubuntu-latest'
         uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
         with:
           python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
@@ -65,7 +76,4 @@ jobs:
           twine
           upload
           --skip-existing
-          dist/*-manylinux*.whl
-          dist/*-macosx*.whl
-          dist/*-win*.whl
-          dist/*.tar.gz || echo "nothing to upload"
+          dist/${{ matrix.wheels }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,6 +5,7 @@ on: [push]
 env:
   TWINE_USERNAME: __token__
   TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+  TWINE_REPOSITORY_URL: 'https://test.pypi.org/legacy/'
 
 jobs:
   build-and-publish:
@@ -44,15 +45,11 @@ jobs:
 
       - name: Build macosx/win Python wheels
         if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
-        run: |
-          python setup.py bdist_wheel
-          twine upload --skip-existing dist/*gimli* --repository-url=https://test.pypi.org/legacy/
+        run: python setup.py bdist_wheel
 
       - name: Build source distribution
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
-        run: |
-          python setup.py sdist
-          twine upload --skip-existing dist/*gimli* --repository-url=https://test.pypi.org/legacy/
+        run: python setup.py sdist
 
       - name: Build manylinux Python wheels
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
@@ -63,7 +60,12 @@ jobs:
           system-packages: 'udunits2-devel'
           pre-build-command: 'export CFLAGS=-I/usr/include/udunits2'
 
-      - name: Upload manylinux distributions
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
-        run: |
-          twine upload --skip-existing dist/*-manylinux*.whl --repository-url=https://test.pypi.org/legacy/
+      - name: Upload distributions
+        run: >-
+          twine
+          upload
+          --skip-existing
+          dist/*-manylinux*.whl
+          dist/*-macosx*.whl
+          dist/*-win*.whl
+          dist/*.tar.gz || echo "nothing to upload"


### PR DESCRIPTION
I've added a GitHub Action to publish to TestPyPI.

The new GitHub action builds a single source distribution and binary distributions for Linux, Mac, and Windows for Python 3.7, 3.8, and 3.9. For Linux, the binary distribution is built as a *manylinux* wheel. If successful, the distributions are uploaded to TestPyPI.

Still to do (but in a different pull request):
* Upload to regular PyPI on a tagged release.
* Limit running this action for a subset of events. Currently, a new version is built on every push.
