### PR TITLE
Deploy to PyPI if a tagged release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,7 +2,8 @@ name: PyPI
 
 on:
   push:
-    tags: ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$
+    tags:
+      - '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
 
 env:
   TWINE_USERNAME: __token__

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,6 +1,8 @@
 name: PyPI
 
-on: [push]
+on:
+  push:
+    tags: ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$
 
 env:
   TWINE_USERNAME: __token__
@@ -23,6 +25,7 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: manylinux
+            python_versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
           - os: macos-latest
             platform: macosx
           - os: windows-latest
@@ -68,7 +71,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
         with:
-          python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
+          python-versions: ${{ python_version }}
           build-requirements: 'cython numpy'
           system-packages: 'udunits2-devel'
           pre-build-command: 'export CFLAGS=-I/usr/include/udunits2'

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -3,7 +3,7 @@ name: PyPI
 on:
   push:
     tags:
-      - '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
+      - 'v*.*.*'
 
 env:
   TWINE_USERNAME: __token__

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -72,7 +72,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
         with:
-          python-versions: ${{ python_version }}
+          python-versions: ${{ matrix.python_version }}
           build-requirements: 'cython numpy'
           system-packages: 'udunits2-devel'
           pre-build-command: 'export CFLAGS=-I/usr/include/udunits2'

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -72,7 +72,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
         with:
-          python-versions: ${{ matrix.python_version }}
+          python-versions: ${{ matrix.python_versions }}
           build-requirements: 'cython numpy'
           system-packages: 'udunits2-devel'
           pre-build-command: 'export CFLAGS=-I/usr/include/udunits2'


### PR DESCRIPTION
Run the deploy to PyPI action for push events with a tag that looks like *vX.Y.Z*. It appears full regular expressions aren't supported (maybe just file globbing?) so I've set it to match tags that match `v*.*.*`.

The regular expression I was trying was for a full Symantic Version string,
```
^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
```
It might be nice to, in the future, have prereleases go to TestPyPI and full releases go to PyPI but I'll cross that bridge later.