### PR TITLE
Add gimli command-line interface

### DIFF
--- a/gimli/cli.py
+++ b/gimli/cli.py
@@ -4,7 +4,6 @@ from io import StringIO
 
 import click
 import numpy as np
-import pandas as pd
 
 from ._udunits2 import IncompatibleUnitsError, UnitNameError, UnitSystem
 from .utils import err, out
@@ -34,10 +33,10 @@ def gimli(ctx, from_, to, data, filename):
     try:
         src_to_dst = src_unit.to(dst_unit)
     except IncompatibleUnitsError:
-        err(f"incompatible units: {src}, {dst}")
+        err(f"incompatible units: {from_}, {to}")
         ctx.exit(-1)
 
-    out("Convering {src} -> {dst}".format(src=str(src_unit), dst=str(dst_unit)))
+    out(f"Convering {from_} -> {to}")
 
     for name in data + filename:
         array = load(name)
@@ -50,5 +49,5 @@ def get_unit_from_system(ctx, unit, system):
     try:
         return system.Unit(unit)
     except UnitNameError:
-        err(f"unknown or poorly-formed unit: {src}")
+        err(f"unknown or poorly-formed unit: {unit}")
         ctx.exit(-1)

--- a/gimli/cli.py
+++ b/gimli/cli.py
@@ -8,9 +8,6 @@ import numpy as np
 from ._udunits2 import IncompatibleUnitsError, UnitNameError, UnitSystem
 from .utils import err, out
 
-load = partial(np.loadtxt, delimiter=",")
-dump = partial(np.savetxt, sys.stdout, delimiter=", ", fmt="%f")
-
 
 @click.command()
 @click.version_option()
@@ -20,6 +17,9 @@ dump = partial(np.savetxt, sys.stdout, delimiter=", ", fmt="%f")
 @click.option("--data", default="")
 @click.pass_context
 def gimli(ctx, from_, to, data, filename):
+    load = partial(np.loadtxt, delimiter=",")
+    dump = partial(np.savetxt, sys.stdout, delimiter=", ", fmt="%f")
+
     if data:
         data = (StringIO(data),)
     else:

--- a/gimli/cli.py
+++ b/gimli/cli.py
@@ -1,0 +1,54 @@
+import sys
+from functools import partial
+from io import StringIO
+
+import click
+import numpy as np
+import pandas as pd
+
+from ._udunits2 import IncompatibleUnitsError, UnitNameError, UnitSystem
+from .utils import err, out
+
+load = partial(np.loadtxt, delimiter=",")
+dump = partial(np.savetxt, sys.stdout, delimiter=", ", fmt="%f")
+
+
+@click.command()
+@click.version_option()
+@click.argument("filename", type=click.File("rb"), nargs=-1)
+@click.option("-f", "--from", "from_", default="1", metavar="UNIT")
+@click.option("-t", "--to", default="1", metavar="UNIT")
+@click.option("--data", default="")
+@click.pass_context
+def gimli(ctx, from_, to, data, filename):
+    if data:
+        data = (StringIO(data),)
+    else:
+        data = ()
+
+    system = UnitSystem()
+
+    src_unit = get_unit_from_system(ctx, from_, system)
+    dst_unit = get_unit_from_system(ctx, to, system)
+
+    try:
+        src_to_dst = src_unit.to(dst_unit)
+    except IncompatibleUnitsError:
+        err(f"incompatible units: {src}, {dst}")
+        ctx.exit(-1)
+
+    out("Convering {src} -> {dst}".format(src=str(src_unit), dst=str(dst_unit)))
+
+    for name in data + filename:
+        array = load(name)
+        dump(src_to_dst(array, out=array))
+
+    ctx.exit(0)
+
+
+def get_unit_from_system(ctx, unit, system):
+    try:
+        return system.Unit(unit)
+    except UnitNameError:
+        err(f"unknown or poorly-formed unit: {src}")
+        ctx.exit(-1)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 import pathlib
-import pkg_resources
 import sys
-from setuptools import setup, find_packages, Extension
+
+import pkg_resources
+from setuptools import Extension, find_packages, setup
 
 
 def read(filename):
@@ -50,7 +51,7 @@ setup(
     ],
     keywords=["units", "unit conversion", "earth science", "model coupling"],
     packages=find_packages(exclude=("tests*",)),
-    entry_points={"console_scripts": ["gimli=gimli.cli:main"]},
+    entry_points={"console_scripts": ["gimli=gimli.cli:gimli"]},
     ext_modules=[
         Extension(
             "gimli._udunits2",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,9 @@
+from io import StringIO
+
+import numpy as np
+import pytest
 from click.testing import CliRunner
+from numpy.testing import assert_array_almost_equal
 
 from gimli import cli
 
@@ -8,10 +13,42 @@ def test_command_line_interface():
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(cli.gimli, ["--help"])
     assert result.exit_code == 0
+    assert result.stdout.startswith("Usage: gimli")
 
     result = runner.invoke(cli.gimli, ["--version"])
     assert result.exit_code == 0
     assert "version" in result.stdout
 
+
+def test_no_op():
+    runner = CliRunner(mix_stderr=False)
     result = runner.invoke(cli.gimli)
     assert result.exit_code == 0
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize("shape", [(-1,), (-1, 1), (3, -1)])
+def test_from_file(tmpdir, shape):
+    values = np.arange(12.0).reshape(shape)
+    with tmpdir.as_cwd():
+        runner = CliRunner(mix_stderr=False)
+
+        np.savetxt("values.txt", values, delimiter=",")
+
+        result = runner.invoke(cli.gimli, ["values.txt"])
+        data = np.loadtxt(StringIO(result.stdout), delimiter=",")
+
+        assert result.exit_code == 0
+        assert_array_almost_equal(np.squeeze(values), np.squeeze(data))
+
+
+def test_opt_data(tmpdir):
+    values = "1,2,3,4,5"
+    with tmpdir.as_cwd():
+        runner = CliRunner(mix_stderr=False)
+
+        result = runner.invoke(cli.gimli, [f"--data={values}"])
+        data = np.loadtxt(StringIO(result.stdout), delimiter=",")
+
+        assert result.exit_code == 0, result.stderr
+        assert_array_almost_equal(data, [1, 2, 3, 4, 5])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,3 +52,26 @@ def test_opt_data(tmpdir):
 
         assert result.exit_code == 0, result.stderr
         assert_array_almost_equal(data, [1, 2, 3, 4, 5])
+
+
+def test_opt_to_from(tmpdir):
+    values = "1,2,3,4,5"
+    with tmpdir.as_cwd():
+        runner = CliRunner(mix_stderr=False)
+
+        result = runner.invoke(cli.gimli, ["--from=m", "--to=km", f"--data={values}"])
+        data = np.loadtxt(StringIO(result.stdout), delimiter=",")
+
+        assert result.exit_code == 0, result.stderr
+        assert_array_almost_equal(data * 1000.0, [1, 2, 3, 4, 5])
+
+
+def test_opt_to_from_incomaptible(tmpdir):
+    values = "1,2,3,4,5"
+    with tmpdir.as_cwd():
+        runner = CliRunner(mix_stderr=False)
+
+        result = runner.invoke(cli.gimli, ["--from=m", "--to=kg", f"--data={values}"])
+
+        assert result.exit_code != 0
+        assert result.stderr.startswith("incompatible units")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+from click.testing import CliRunner
+
+from gimli import cli
+
+
+def test_command_line_interface():
+    """Test the CLI."""
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(cli.gimli, ["--help"])
+    assert result.exit_code == 0
+
+    result = runner.invoke(cli.gimli, ["--version"])
+    assert result.exit_code == 0
+    assert "version" in result.stdout
+
+    result = runner.invoke(cli.gimli)
+    assert result.exit_code == 0


### PR DESCRIPTION
This pull request adds a simple command-line interface for *gimli*.
```bash
$ cat values.txt
1.2, 3.4, 6.7
10.2, 6.4, 12.7

$ gimli --to=m --from=km values.csv  # convert values in a csv file
1200.000000, 3400.000000, 6700.000000
10200.000000, 6400.000000, 12700.000000

$ gimli --to=m --from=km --data=2,3,4  # convert values from the command line
2000.000000
3000.000000
4000.000000
```