### PR TITLE
Change name of package to gimli.units

### DIFF
--- a/gimli/__init__.py
+++ b/gimli/__init__.py
@@ -10,8 +10,12 @@ from ._udunits2 import (
 )
 from .errors import IncompatibleUnitsError
 
-__version__ = pkg_resources.get_distribution("gimli").version
+
+units = UnitSystem()
+
+__version__ = pkg_resources.get_distribution("gimli.units").version
 __all__ = [
+    "units",
     "IncompatibleUnitsError",
     "Unit",
     "UnitEncoding",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if sys.platform.startswith("win"):
 numpy_incl = pkg_resources.resource_filename("numpy", "core/include")
 
 setup(
-    name="gimli",
+    name="gimli.units",
     version="0.2.0b1.dev0",
     description="An object-oriented Python interface to udunits",
     long_description=long_description,


### PR DESCRIPTION
This pull request changes the name of the package from just *gimli to *gimli.units* (the package name *gimli* is already taken on PyPI). I've also added the *units* variable (i.e. `gimli.units`) to be the default system of units.
