### PR TITLE
Fix scalar bug

### DIFF
--- a/gimli/cli.py
+++ b/gimli/cli.py
@@ -40,7 +40,7 @@ def gimli(ctx, from_, to, data, filename):
 
     for name in data + filename:
         array = load(name)
-        dump(src_to_dst(array, out=array))
+        dump(np.atleast_1d(src_to_dst(array, out=array)))
 
     ctx.exit(0)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,16 +42,19 @@ def test_from_file(tmpdir, shape):
         assert_array_almost_equal(np.squeeze(values), np.squeeze(data))
 
 
-def test_opt_data(tmpdir):
-    values = "1,2,3,4,5"
+@pytest.mark.parametrize(
+    "values", ["1,2,3,4,5", "2", "3.0", "1e-3", "0.1, 1e2", "-2.3"]
+)
+def test_opt_data(tmpdir, values):
     with tmpdir.as_cwd():
         runner = CliRunner(mix_stderr=False)
 
         result = runner.invoke(cli.gimli, [f"--data={values}"])
         data = np.loadtxt(StringIO(result.stdout), delimiter=",")
+        expected = np.loadtxt(StringIO(values), delimiter=",")
 
         assert result.exit_code == 0, result.stderr
-        assert_array_almost_equal(data, [1, 2, 3, 4, 5])
+        assert_array_almost_equal(data, expected)
 
 
 def test_opt_to_from(tmpdir):


### PR DESCRIPTION
This pull request fixes a bug that occurs when passing a single value to the command line interface. For example,
```bash
$ gimli --data=1.0
```
