### PR TITLE
Fix version option

### DIFF
--- a/gimli/cli.py
+++ b/gimli/cli.py
@@ -10,7 +10,7 @@ from .utils import err, out
 
 
 @click.command()
-@click.version_option()
+@click.version_option(package_name="gimli.units")
 @click.argument("filename", type=click.File("rb"), nargs=-1)
 @click.option("-f", "--from", "from_", default="1", metavar="UNIT")
 @click.option("-t", "--to", default="1", metavar="UNIT")


### PR DESCRIPTION
The `--version` option for the *gimli* command was broken. I've fixed it by passing the *package_name* keyword to the *click.version_option* decorator.

This is what the error looked like,
```bash
$ gimli --version
Traceback (most recent call last):
...
RuntimeError: 'gimli' is not installed. Try passing 'package_name' instead.
```
Now after the fix,
```bash
$ gimli --version
gimli, version 0.2.2.dev0
```
I think the issue was that the command is called *gimli* but the package is called *gimli.units* and so *click* got confused when trying to find the version.