### PR TITLE
fix: AttributeError when deallocating UnitSystem

### DIFF
--- a/gimli/_udunits2.pyx
+++ b/gimli/_udunits2.pyx
@@ -343,7 +343,7 @@ cdef class _UnitSystem:
         free(self._filepath)
         self._unit_system = NULL
         self._filepath = NULL
-        self._status = UnitStatus.SUCCESS
+        self._status = 0
 
     def __str__(self):
         return str(self.database)


### PR DESCRIPTION
This pull request fixes an issue when quitting Python after creating a new *UnitSystem*.
```python
>>> from gimli import units
>>> exit()
AttributeError: 'NoneType' object has no attribute 'SUCCESS'
Exception ignored in: 'gimli._udunits2._UnitSystem.__dealloc__'
AttributeError: 'NoneType' object has no attribute 'SUCCESS'
```
The issue was in the `__dealloc__` method of the *cdef* class, `_UnitSystem`, when the *_status* attribute is reset. We had been setting it to `UnitStatus.SUCCESS` but the `UnitStatus` *enum* is not a thing within `_UnitSystem`. Instead, I've just set it to 0.