### PR TITLE
maint: move static metadata to setup.cfg; modify build-system requires

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -55,18 +55,18 @@ jobs:
           conda list
 
       - name: Install build environment
-        run: pip install twine wheel numpy cython
+        run: pip install build twine
 
       - name: Build macosx/win Python wheels
         if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
         run: |
-          conda install --file=requirements.txt udunits2
-          python setup.py bdist_wheel
+          conda install udunits2
+          python -m build --wheel
 
       - name: Build source distribution
         if: matrix.os == 'ubuntu-latest'
         run: |
-          python setup.py sdist
+          python -m build --sdist
           twine upload --skip-existing dist/*.tar.gz
 
       - name: Build manylinux Python wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,18 +55,18 @@ jobs:
           conda list
 
       - name: Install build environment
-        run: pip install twine wheel numpy cython
+        run: pip install build twine
 
       - name: Build macosx/win Python wheels
         if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
         run: |
-          conda install --file=requirements.txt udunits2
-          python setup.py bdist_wheel
+          conda install udunits2
+          python -m build --wheel
 
       - name: Build source distribution
         if: matrix.os == 'ubuntu-latest'
         run: |
-          python setup.py sdist
+          python -m build --sdist
           twine upload --skip-existing dist/*.tar.gz
 
       - name: Build manylinux Python wheels

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ pretty: ## reformat files to make them look pretty
 	black setup.py gimli tests
 
 test: ## run tests quickly with the default Python
-	py.test
+	pytest
 
 test-all: ## run tests on every Python version with tox
 	tox
@@ -86,9 +86,8 @@ release: dist ## package and upload a release
 	twine upload dist/*
 
 dist: clean ## builds source and wheel package
-	python setup.py sdist
-	python setup.py bdist_wheel
+	python -m build
 	ls -l dist
 
 install: clean ## install the package to the active Python's site-packages
-	python setup.py install
+	pip install .

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ From Source
 ~~~~~~~~~~~
 
 After downloading the *gimli* source code, run the following from
-*gimli*'s top-level folder (the one that contains *setup.py*) to install
+*gimli*'s top-level folder (the one that contains *pyproject.toml*) to install
 *gimli* into the current environment:
 
 ::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["cython", "numpy", "setuptools", "wheel"]
+requires = ["cython", "oldest-supported-numpy", "setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,45 @@
+[metadata]
+name = gimli.units
+version = 0.3.1.dev0
+description = An object-oriented Python interface to udunits2
+long_description = file: README.rst, AUTHORS.rst, CHANGES.rst
+long_description_content_type = text/x-rst
+keywords = units, unit conversion, earth science, model coupling
+author = Eric Hutton
+author_email = huttone@colorado.edu
+license = MIT
+license_files = LICENSE
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Cython
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: Implementation :: CPython
+    Topic :: Scientific/Engineering :: Physics
+url = https://csdms.colorado.edu
+project_urls =
+    Source Code = https://github.com/mcflugen/gimli
+
+[options]
+include_package_data = True
+packages = find:
+python_requires = >=3.7
+install_requires =
+    click
+    numpy
+
+[options.entry_points]
+console_scripts =
+    gimli = gimli.cli:gimli
+
+[options.packages.find]
+exclude = tests*
+
 [flake8]
 exclude = docs
 ignore =

--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,7 @@ import pathlib
 import sys
 
 import pkg_resources
-from setuptools import Extension, find_packages, setup
-
-
-def read(filename):
-    with open(filename, "r", encoding="utf-8") as fp:
-        return fp.read()
-
-
-long_description = u"\n\n".join(
-    [
-        read("README.rst"),
-        read("AUTHORS.rst"),
-        read("CHANGES.rst"),
-    ]
-)
+from setuptools import Extension, setup
 
 
 udunits2_prefix = pathlib.Path(sys.prefix)
@@ -25,34 +11,8 @@ if sys.platform.startswith("win"):
 
 numpy_incl = pkg_resources.resource_filename("numpy", "core/include")
 
+# see setup.cfg for static metadata
 setup(
-    name="gimli.units",
-    version="0.3.1.dev0",
-    description="An object-oriented Python interface to udunits",
-    long_description=long_description,
-    author="Eric Hutton",
-    author_email="huttone@colorado.edu",
-    url="http://csdms.colorado.edu",
-    python_requires=">=3.7",
-    install_requires=open("requirements.txt", "r").read().splitlines(),
-    include_package_data=True,
-    setup_requires=[],
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Cython",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Topic :: Scientific/Engineering :: Physics",
-    ],
-    keywords=["units", "unit conversion", "earth science", "model coupling"],
-    packages=find_packages(exclude=("tests*",)),
-    entry_points={"console_scripts": ["gimli=gimli.cli:gimli"]},
     ext_modules=[
         Extension(
             "gimli._udunits2",


### PR DESCRIPTION
Here's a summary:

- Move static metadata to setup.cfg, but obviously keep setup.py for dynamic metadata required for Cython
- Add Source Code URL (was missing)
- Slight modification to description to specify udunits2 (was udunits)
- Python package builds normally only need `build`, other requirements are in pyproject.toml
- Use [oldest-supported-numpy](https://pypi.org/project/oldest-supported-numpy/) as build requirement to maintain ABI compatibility with binary wheels
-  Specify setuptools build backend