### PR TITLE
Reorganize package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,8 @@
 
 An object-oriented Python interface to [udunits2][udunits-link] built with cython.
 
-## Requirements
-
-*udunits2* is the unit conversion C library that
-*gimli* wraps using *cython*. The easiest way to install *udunits2* is
-through Anaconda (see the Install section), or *yum* (as *udunits2-devel*
-on ubuntu-based Linux). It can, however, also be compiled and installed from source.
-You can get the source code either as a [.tar.gz][udunits-download] or from
-[GitHub][udunits-github].
-
-All other requirements are available using either *pip* or *conda*. To
-see a full listing of the requirements, have a look at the project's
-*requirements.in* file.
+**NOTE: *gimli.units* includes a vendored version of *udunits2* so that you do not
+have to install the *udunits2* library separately.**
 
 ## Installation
 
@@ -72,24 +62,24 @@ the *udunits2* library. *gimli*, however, also comes with a
 You primarily will access *gimli* through *gimli.units*,
 
 ```python
->>> from gimli import units
+>>> from gimli.units import units
 ```
 
 *units* is an instance of the default *UnitSystem* class, which contains
 all of the units contained in a given unit system. If you like, you can create
 your own unit system but, typically, the default should be fine.
 
-To get a specific unit from the system, do so by passing a unit
-string to the *Units* class. For example,
+*units* is a *dict*-like object whose keys are strings representing units
+and values are instances of those units. For example,
 
 ```python
->>> units.Unit("m")
+>>> units["m"]
 Unit('meter')
->>> units.Unit("m/s")
+>>> units["m/s"]
 Unit('meter-second^-1')
->>> units.Unit("kg m-3")
+>>> units["kg m-3"]
 Unit('meter^-3-kilogram')
->>> units.Unit("N m")
+>>> units["N m"]
 Unit('joule')
 ```
 
@@ -97,8 +87,8 @@ Every *Unit* instance has a *to* method, which returns a unit converter
 for converting values from one unit to another,
 
 ```python
->>> lbs = units.Unit("lb")
->>> kgs = units.Unit("kg")
+>>> lbs = units["lb"]
+>>> kgs = units["kg"]
 >>> kgs_to_lbs = kgs.to(lbs)
 >>> kgs_to_lbs(1.0)
 2.2046226218487757
@@ -107,8 +97,8 @@ for converting values from one unit to another,
 You can also construct units that are a combination of other units.
 
 ```python
->>> ft_per_s = units.Unit("ft / s")
->>> m_per_s = units.Unit("m s-1")
+>>> ft_per_s = units["ft / s"]
+>>> m_per_s = units["m s-1"]
 >>> ft_per_s.to(m_per_s)([1.0, 2.0])
 array([0.3048, 0.6096])
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,19 +117,19 @@ before-all = "brew install automake libtool texinfo"
 before-build = "pip install delvewheel"
 before-all = [
     "cd {package}\\extern\\expat-2.6.0",
-    "cmake -S . -DCMAKE_INSTALL_PREFIX={package}\\_inst",
+    "cmake -S . -DCMAKE_INSTALL_PREFIX={package}\\dist\\extern",
     "cmake --build . --config Release",
     "cmake --build . --config Release --target install",
-    "set LIB=%LIBRARY_LIB%;{package}\\_inst\\lib;%LIB%",
-    "set LIBPATH=%LIBRARY_LIB%;{package}\\_inst\\lib;%LIBPATH%",
-    "set INCLUDE={package}\\_inst\\include;%INCLUDE%",
+    "set LIB=%LIBRARY_LIB%;{package}\\dist\\extern\\lib;%LIB%",
+    "set LIBPATH=%LIBRARY_LIB%;{package}\\dist\\extern\\lib;%LIBPATH%",
+    "set INCLUDE={package}\\dist\\extern\\include;%INCLUDE%",
     "cd {package}\\extern\\udunits-2.2.28",
-    "set CFLAGS=\"-I{package}\\_inst\\include\"",
-    "cmake -S . -DCMAKE_INSTALL_PREFIX={package}\\_inst -D EXPAT_INCLUDE_DIR={package}\\_inst\\include\\expat.h",
+    "set CFLAGS=\"-I{package}\\dist\\extern\\include\"",
+    "cmake -S . -DCMAKE_INSTALL_PREFIX={package}\\dist\\extern -D EXPAT_INCLUDE_DIR={package}\\dist\\extern\\include\\expat.h",
     "cmake --build . --config Release --target libudunits2",
     "cmake --build . --config Release --target install",
 ]
-repair-wheel-command = "delvewheel repair --add-path=_inst\\bin -w {dest_dir} {wheel}"
+repair-wheel-command = "delvewheel repair --add-path=dist\\extern\\bin -w {dest_dir} {wheel}"
 
 [tool.isort]
 multi_line_output = 3

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 udunits2_prefix = os.environ.get("WITH_UDUNITS2", sys.prefix)
 if sys.platform.startswith("win") and "WITH_UDUNITS" not in os.environ:
     udunits2_prefix = os.path.join(sys.prefix, "Library")
-vendored_prefix = os.path.join(os.path.dirname(__file__), "_inst")
+vendored_prefix = os.path.join(os.path.dirname(__file__), "dist", "extern")
 
 setup(
     include_package_data=True,

--- a/src/gimli/__init__.py
+++ b/src/gimli/__init__.py
@@ -1,7 +1,5 @@
-from gimli._system import UnitSystem
+# from gimli._system import UnitSystem
 from gimli._version import __version__
-
-units = UnitSystem()
-del UnitSystem
+from gimli.units import units
 
 __all__ = ["__version__", "units"]

--- a/src/gimli/__init__.py
+++ b/src/gimli/__init__.py
@@ -1,22 +1,7 @@
-from gimli._udunits2 import Unit
-from gimli._udunits2 import UnitEncoding
-from gimli._udunits2 import UnitFormatting
-from gimli._udunits2 import UnitNameError
-from gimli._udunits2 import UnitStatus
-from gimli._udunits2 import UnitSystem
+from gimli._system import UnitSystem
 from gimli._version import __version__
-from gimli.errors import IncompatibleUnitsError
 
 units = UnitSystem()
+del UnitSystem
 
-__all__ = [
-    "__version__",
-    "units",
-    "IncompatibleUnitsError",
-    "Unit",
-    "UnitEncoding",
-    "UnitFormatting",
-    "UnitNameError",
-    "UnitStatus",
-    "UnitSystem",
-]
+__all__ = ["__version__", "units"]

--- a/src/gimli/_constants.py
+++ b/src/gimli/_constants.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from enum import IntEnum
+from enum import IntFlag
+
+
+class UnitStatus(IntEnum):
+    SUCCESS = 0
+    BAD_ARG = 1
+    EXISTS = 2
+    NO_UNIT = 3
+    OS = 4
+    NOT_SAME_SYSTEM = 5
+    MEANINGLESS = 6
+    NO_SECOND = 7
+    VISIT_ERROR = 8
+    CANT_FORMAT = 9
+    SYNTAX = 10
+    UNKNOWN = 11
+    OPEN_ARG = 12
+    OPEN_ENV = 13
+    OPEN_DEFAULT = 14
+    PARSE = 15
+
+
+class UnitEncoding(IntEnum):
+    ASCII = 0
+    ISO_8859_1 = 1
+    LATIN1 = 1
+    UTF8 = 2
+
+
+class UnitFormatting(IntFlag):
+    NAMES = 4
+    DEFINITIONS = 8
+
+
+STATUS_MESSAGE = {
+    UnitStatus.SUCCESS: "Success",
+    UnitStatus.BAD_ARG: "An argument violates the function's contract",
+    UnitStatus.EXISTS: "Unit, prefix, or identifier already exists",
+    UnitStatus.NO_UNIT: "No such unit exists",
+    UnitStatus.OS: "Operating-system error.  See 'errno'",
+    UnitStatus.NOT_SAME_SYSTEM: "The units belong to different unit-systems",
+    UnitStatus.MEANINGLESS: "The operation on the unit(s) is meaningless",
+    UnitStatus.NO_SECOND: "The unit-system doesn't have a unit named 'second'",
+    UnitStatus.VISIT_ERROR: "An error occurred while visiting a unit",
+    UnitStatus.CANT_FORMAT: "A unit can't be formatted in the desired manner",
+    UnitStatus.SYNTAX: "string unit representation contains syntax error",
+    UnitStatus.UNKNOWN: "string unit representation contains unknown word",
+    UnitStatus.OPEN_ARG: "Can't open argument-specified unit database",
+    UnitStatus.OPEN_ENV: "Can't open environment-specified unit database",
+    UnitStatus.OPEN_DEFAULT: "Can't open installed, default, unit database",
+    UnitStatus.PARSE: "Error parsing unit specification",
+}
+
+
+UDUNITS_ENCODING = {
+    "ascii": UnitEncoding.ASCII,
+    "us-ascii": UnitEncoding.ASCII,
+    "iso-8859-1": UnitEncoding.ISO_8859_1,
+    "iso8859-1": UnitEncoding.ISO_8859_1,
+    "latin-1": UnitEncoding.LATIN1,
+    "latin1": UnitEncoding.LATIN1,
+    "utf-8": UnitEncoding.UTF8,
+    "utf8": UnitEncoding.UTF8,
+}

--- a/src/gimli/_main.py
+++ b/src/gimli/_main.py
@@ -5,12 +5,12 @@ from typing import Any
 
 import numpy as np
 
-from gimli._udunits2 import IncompatibleUnitsError
-from gimli._udunits2 import UnitNameError
-from gimli._udunits2 import UnitSystem
+from gimli._system import UnitSystem
 from gimli._utils import err
 from gimli._utils import out
 from gimli._version import __version__
+from gimli.errors import IncompatibleUnitsError
+from gimli.errors import UnitNameError
 
 system = UnitSystem()
 

--- a/src/gimli/_main.py
+++ b/src/gimli/_main.py
@@ -5,7 +5,9 @@ from typing import Any
 
 import numpy as np
 
+from gimli._constants import STATUS_MESSAGE
 from gimli._system import UnitSystem
+from gimli._udunits2 import UdunitsError
 from gimli._utils import err
 from gimli._utils import out
 from gimli._version import __version__
@@ -57,6 +59,12 @@ def main(argv: tuple[str, ...] | None = None) -> int:
         src_to_dst = args.from_.to(args.to)
     except IncompatibleUnitsError:
         err(f"[error] incompatible units: {args.from_!s}, {args.to!s}")
+        return 1
+    except UdunitsError as error:
+        err(
+            f"[error] udunits internal error (error code {error.code}:"
+            f" {STATUS_MESSAGE.get(error.code, 'unknown')})"
+        )
         return 1
 
     if not args.quiet:

--- a/src/gimli/_system.py
+++ b/src/gimli/_system.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import contextlib
+
+from gimli._udunits2 import Unit
+from gimli._udunits2 import _UnitSystem
+
+
+class UnitSystem(_UnitSystem):
+
+    """A system of units.
+
+    A unit-system is a set of units that are all defined in terms of
+    the same set of base units. In the SI system of units, for example,
+    the base units are the meter, kilogram, second, ampere, kelvin,
+    mole, and candela. (For definitions of these base units,
+    see http://physics.nist.gov/cuu/Units/current.html)
+
+    In the UDUNITS-2 package, every accessible unit belongs to one and
+    only one unit-system. It is not possible to convert numeric values
+    between units of different unit-systems. Similarly, units belonging
+    to different unit-systems always compare unequal.
+
+    Parameters
+    ----------
+    filepath : str, optional
+        Path to a *udunits2* xml-formatted unit database. If not provided,
+        a default system of units is used.
+    """
+
+    def __init__(self, filepath: str | None = None):
+        self._registry: dict[str, Unit] = {}
+
+    def __getitem__(self, key: str) -> Unit:
+        with contextlib.suppress(KeyError):
+            return self._registry[key]
+        self._registry[key] = self.Unit(key)
+        return self._registry[key]

--- a/src/gimli/_system.py
+++ b/src/gimli/_system.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from collections import UserDict
+import os
+from collections.abc import Generator
+from collections.abc import Mapping
+from xml.etree import ElementTree
 
 from gimli._udunits2 import Unit
 from gimli._udunits2 import _UnitSystem
 
 
-class UnitSystem(UserDict[str, Unit], _UnitSystem):
+class UnitSystem(Mapping[str, Unit], _UnitSystem):
 
     """A system of units.
 
@@ -31,7 +34,53 @@ class UnitSystem(UserDict[str, Unit], _UnitSystem):
     def __init__(self, filepath: str | None = None):
         self.data: dict[str, Unit] = {}
 
+        for symbol in _load_all_symbols_from_database(self.database):
+            self[symbol]
+
     def __getitem__(self, key: str) -> Unit:
+        key = key.strip()
+
         if key not in self.data:
-            self.data[key] = self.Unit(key)
-        return self.data[key]
+            unit = self.Unit(key)
+            if unit.name not in self.data:
+                self.data[unit.name] = unit
+            return self.data[unit.name]
+        else:
+            return self.data[key]
+
+    def __iter__(self) -> Generator[str, None, None]:
+        yield from self.data
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __str__(self) -> str:
+        return str(self.data)
+
+    def __repr__(self) -> str:
+        return repr(self.data)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, UnitSystem):
+            return NotImplemented
+        return os.path.samefile(self.database, other.database)
+
+
+def _load_all_symbols_from_database(path: str) -> set[str]:
+    base = os.path.dirname(path)
+
+    roots = [
+        ElementTree.parse(os.path.join(base, child.text)).getroot()
+        for child in ElementTree.parse(path).getroot()
+        if child.tag == "import" and isinstance(child.text, str)
+    ]
+
+    symbols: set[str] = set()
+    for root in roots:
+        symbols |= {
+            element.text
+            for element in root.findall("unit/symbol")
+            if isinstance(element.text, str)
+        }
+
+    return symbols

--- a/src/gimli/_system.py
+++ b/src/gimli/_system.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import contextlib
+from collections import UserDict
 
 from gimli._udunits2 import Unit
 from gimli._udunits2 import _UnitSystem
 
 
-class UnitSystem(_UnitSystem):
+class UnitSystem(UserDict[str, Unit], _UnitSystem):
 
     """A system of units.
 
@@ -29,10 +29,9 @@ class UnitSystem(_UnitSystem):
     """
 
     def __init__(self, filepath: str | None = None):
-        self._registry: dict[str, Unit] = {}
+        self.data: dict[str, Unit] = {}
 
     def __getitem__(self, key: str) -> Unit:
-        with contextlib.suppress(KeyError):
-            return self._registry[key]
-        self._registry[key] = self.Unit(key)
-        return self._registry[key]
+        if key not in self.data:
+            self.data[key] = self.Unit(key)
+        return self.data[key]

--- a/src/gimli/_udunits2.pyx
+++ b/src/gimli/_udunits2.pyx
@@ -4,8 +4,6 @@ from __future__ import annotations
 import os
 import pathlib
 import sys
-from enum import Enum
-from enum import Flag
 
 import numpy as np
 
@@ -14,8 +12,14 @@ from libc.stdlib cimport free
 from libc.stdlib cimport malloc
 from libc.string cimport strcpy
 
+from gimli._constants import UDUNITS_ENCODING
+from gimli._constants import UnitEncoding
+from gimli._constants import UnitFormatting
+from gimli._constants import UnitStatus
 from gimli._utils import suppress_stdout
 from gimli.errors import IncompatibleUnitsError
+from gimli.errors import UnitError
+from gimli.errors import UnitNameError
 
 if sys.version_info >= (3, 12):  # pragma: no cover (PY12+)
     import importlib.resources as importlib_resources
@@ -27,92 +31,6 @@ FLOAT = np.float32
 
 ctypedef np.double_t DOUBLE_t
 ctypedef np.float_t FLOAT_t
-
-
-class UnitError(Exception):
-
-    def __init__(self, code: int, msg: str =""):
-        self._code = code
-        self._msg = msg
-
-    def __str__(self) -> str:
-        msg = self._msg or STATUS_MESSAGE.get(self._code, "Unknown")
-        return "{0} (status {1})".format(msg, self._code)
-
-
-class UnitNameError(UnitError):
-
-    def __init__(self, name: str, code: int):
-        self._name = name
-        self._code = code
-
-    def __str__(self) -> str:
-        return "{0!r}: {1} (status {2})".format(
-            self._name, STATUS_MESSAGE.get(self._code, "Unknown"), self._code
-        )
-
-
-class UnitEncoding(int, Enum):
-    ASCII = 0
-    ISO_8859_1 = 1
-    LATIN1 = 1
-    UTF8 = 2
-
-
-UDUNITS_ENCODING = {
-    "ascii": UnitEncoding.ASCII,
-    "us-ascii": UnitEncoding.ASCII,
-    "iso-8859-1": UnitEncoding.ISO_8859_1,
-    "iso8859-1": UnitEncoding.ISO_8859_1,
-    "latin-1": UnitEncoding.LATIN1,
-    "latin1": UnitEncoding.LATIN1,
-    "utf-8": UnitEncoding.UTF8,
-    "utf8": UnitEncoding.UTF8,
-}
-
-
-class UnitFormatting(int, Flag):
-    NAMES = 4
-    DEFINITIONS = 8
-
-
-class UnitStatus(int, Enum):
-    SUCCESS = 0
-    BAD_ARG = 1
-    EXISTS = 2
-    NO_UNIT = 3
-    OS = 4
-    NOT_SAME_SYSTEM = 5
-    MEANINGLESS = 6
-    NO_SECOND = 7
-    VISIT_ERROR = 8
-    CANT_FORMAT = 9
-    SYNTAX = 10
-    UNKNOWN = 11
-    OPEN_ARG = 12
-    OPEN_ENV = 13
-    OPEN_DEFAULT = 14
-    PARSE = 15
-
-
-STATUS_MESSAGE = {
-    UnitStatus.SUCCESS: "Success",
-    UnitStatus.BAD_ARG:	"An argument violates the function's contract",
-    UnitStatus.EXISTS: "Unit, prefix, or identifier already exists",
-    UnitStatus.NO_UNIT: "No such unit exists",
-    UnitStatus.OS: "Operating-system error.  See 'errno'",
-    UnitStatus.NOT_SAME_SYSTEM: "The units belong to different unit-systems",
-    UnitStatus.MEANINGLESS: "The operation on the unit(s) is meaningless",
-    UnitStatus.NO_SECOND: "The unit-system doesn't have a unit named 'second'",
-    UnitStatus.VISIT_ERROR: "An error occurred while visiting a unit",
-    UnitStatus.CANT_FORMAT: "A unit can't be formatted in the desired manner",
-    UnitStatus.SYNTAX: "string unit representation contains syntax error",
-    UnitStatus.UNKNOWN: "string unit representation contains unknown word",
-    UnitStatus.OPEN_ARG: "Can't open argument-specified unit database",
-    UnitStatus.OPEN_ENV: "Can't open environment-specified unit database",
-    UnitStatus.OPEN_DEFAULT: "Can't open installed, default, unit database",
-    UnitStatus.PARSE: "Error parsing unit specification",
-}
 
 
 cdef extern from "udunits2.h":
@@ -154,39 +72,6 @@ cdef extern from "udunits2.h":
     void cv_free(cv_converter* conv)
 
     ut_status ut_get_status()
-
-
-class UnitSystem(_UnitSystem):
-
-    """A system of units.
-
-    A unit-system is a set of units that are all defined in terms of
-    the same set of base units. In the SI system of units, for example,
-    the base units are the meter, kilogram, second, ampere, kelvin,
-    mole, and candela. (For definitions of these base units,
-    see http://physics.nist.gov/cuu/Units/current.html)
-
-    In the UDUNITS-2 package, every accessible unit belongs to one and
-    only one unit-system. It is not possible to convert numeric values
-    between units of different unit-systems. Similarly, units belonging
-    to different unit-systems always compare unequal.
-
-    Parameters
-    ----------
-    filepath : str, optional
-        Path to a *udunits2* xml-formatted unit database. If not provided,
-        a default system of units is used.
-    """
-    def __init__(self, filepath: str | None=None):
-        self._registry = dict()
-
-    def __getitem__(self, key: str) -> Unit:
-        try:
-            return self._registry[key]
-        except KeyError:
-            pass
-        self._registry[key] = self.Unit(key)
-        return self._registry[key]
 
 
 cdef class _UnitSystem:
@@ -361,7 +246,7 @@ cdef class _UnitSystem:
         return str(self.database)
 
     def __repr__(self):
-        return "UnitSystem({0!r})".format(str(self.database))
+        return "UnitSystem({str(self.database)!r})"
 
     def __eq__(self, other):
         return self.database.samefile(other.database)

--- a/src/gimli/_udunits2.pyx
+++ b/src/gimli/_udunits2.pyx
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-import pathlib
 import sys
 
 import numpy as np
@@ -83,7 +82,7 @@ cdef class _UnitSystem:
         cdef char* path
 
         filepath, self._status = _UnitSystem.get_xml_path(filepath)
-        as_bytes = str(filepath).encode("utf-8")
+        as_bytes = filepath.encode("utf-8")
 
         self._filepath = <char*>malloc((len(as_bytes) + 1) * sizeof(char))
         strcpy(self._filepath, as_bytes)
@@ -96,7 +95,7 @@ cdef class _UnitSystem:
             raise UnitError(status)
 
     @staticmethod
-    def get_xml_path(filepath=None):
+    def get_xml_path(filepath: str | None=None) -> str:
         """Get the path to a unit database.
 
         Parameters
@@ -126,7 +125,7 @@ cdef class _UnitSystem:
                 status = UnitStatus.OPEN_ENV
         else:
             status = UnitStatus.OPEN_ARG
-        return pathlib.Path(filepath), status
+        return filepath, status
 
     def dimensionless_unit(self):
         """The dimensionless unit used by the unit system.
@@ -211,9 +210,9 @@ cdef class _UnitSystem:
 
 
     @property
-    def database(self):
+    def database(self) -> str:
         """Path to the unit-database being used."""
-        return pathlib.Path(self._filepath.decode())
+        return self._filepath.decode()
 
     @property
     def status(self):

--- a/src/gimli/_udunits2.pyx
+++ b/src/gimli/_udunits2.pyx
@@ -210,15 +210,6 @@ cdef class _UnitSystem:
         self._filepath = NULL
         self._status = 0
 
-    def __str__(self):
-        return str(self.database)
-
-    def __repr__(self):
-        return f"UnitSystem({str(self.database)!r})"
-
-    def __eq__(self, other):
-        return os.path.samefile(self.database, other.database)
-
 
 cdef class Unit:
 

--- a/src/gimli/_udunits2.pyx
+++ b/src/gimli/_udunits2.pyx
@@ -95,7 +95,7 @@ cdef class _UnitSystem:
             raise UnitError(status)
 
     @staticmethod
-    def get_xml_path(filepath: str | None=None) -> str:
+    def get_xml_path(filepath: str | None=None) -> tuple[str, UnitStatus]:
         """Get the path to a unit database.
 
         Parameters
@@ -248,7 +248,7 @@ cdef class _UnitSystem:
         return "UnitSystem({str(self.database)!r})"
 
     def __eq__(self, other):
-        return self.database.samefile(other.database)
+        return os.path.samefile(self.database, other.database)
 
 
 cdef class Unit:

--- a/src/gimli/_udunits2.pyx
+++ b/src/gimli/_udunits2.pyx
@@ -255,7 +255,8 @@ cdef class Unit:
         return self.UnitConverter(unit)
 
     cpdef UnitConverter(self, Unit unit):
-        converter = ut_get_converter(self._unit, unit._unit)
+        with suppress_stdout():
+            converter = ut_get_converter(self._unit, unit._unit)
 
         if converter == NULL:
             status = ut_get_status()

--- a/src/gimli/_utils.py
+++ b/src/gimli/_utils.py
@@ -10,6 +10,7 @@ else:  # pragma: no cover (<PY312)
     import importlib_resources
 
 from gimli._constants import UnitStatus
+from gimli.errors import DatabaseNotFoundError
 
 out = partial(print, file=sys.stderr)
 err = partial(print, file=sys.stderr)
@@ -63,8 +64,6 @@ def get_xml_path(filepath: str | None = None) -> tuple[str, UnitStatus]:
         status = UnitStatus.OPEN_ARG
 
     if not os.path.isfile(filepath):
-        raise RuntimeError(
-            f"{filepath}: unable to locate units database (path does not exist)"
-        )
+        raise DatabaseNotFoundError(filepath, status)
 
     return filepath, status

--- a/src/gimli/errors.py
+++ b/src/gimli/errors.py
@@ -1,3 +1,9 @@
+from __future__ import annotations
+
+from gimli._constants import STATUS_MESSAGE
+from gimli._constants import UnitStatus
+
+
 class GimliError(Exception):
     pass
 
@@ -9,3 +15,22 @@ class IncompatibleUnitsError(GimliError):
 
     def __str__(self) -> str:
         return f"incompatible units ({self._src!r}, {self._dst!r})"
+
+
+class UnitError(GimliError):
+    def __init__(self, code: UnitStatus, msg: str | None = None):
+        self._code = code
+        self._msg = msg or STATUS_MESSAGE.get(self._code, "Unknown")
+
+    def __str__(self) -> str:
+        return f"{self._msg} (status {self._code})"
+
+
+class UnitNameError(UnitError):
+    def __init__(self, name: str, code: UnitStatus):
+        self._name = name
+        self._code = code
+        self._msg = STATUS_MESSAGE.get(self._code, "Unknown")
+
+    def __str__(self) -> str:
+        return "{0!r}: {self._msg} (status {2})"

--- a/src/gimli/errors.py
+++ b/src/gimli/errors.py
@@ -33,4 +33,4 @@ class UnitNameError(UnitError):
         self._msg = STATUS_MESSAGE.get(self._code, "Unknown")
 
     def __str__(self) -> str:
-        return "{0!r}: {self._msg} (status {2})"
+        return f"{self._name!r}: {self._msg} (status {self._code})"

--- a/src/gimli/errors.py
+++ b/src/gimli/errors.py
@@ -34,3 +34,15 @@ class UnitNameError(UnitError):
 
     def __str__(self) -> str:
         return f"{self._name!r}: {self._msg} (status {self._code})"
+
+
+class DatabaseNotFoundError(GimliError):
+    def __init__(self, path: str, status: int):
+        self._path = str(path)
+        self._status = status
+
+    def __str__(self) -> str:
+        return (
+            f"{self._path}: unable to locate units database"
+            f" ({self._status}): path does not exist"
+        )

--- a/src/gimli/units.py
+++ b/src/gimli/units.py
@@ -1,5 +1,3 @@
-from types import MappingProxyType
-
 from gimli._system import UnitSystem
 
-units = MappingProxyType(UnitSystem())
+units = UnitSystem()

--- a/src/gimli/units.py
+++ b/src/gimli/units.py
@@ -1,0 +1,5 @@
+from types import MappingProxyType
+
+from gimli._system import UnitSystem
+
+units = MappingProxyType(UnitSystem())

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -220,14 +220,14 @@ def test_unit_converter_same_units(system):
     [("not_a_unit", "m"), ("m", "not_a_unit"), ("not_a_unit", "not_a_unit")],
 )
 def test_unit_converter_bad_from_units(system, to_, from_):
-    with pytest.raises(UnitNameError):
+    with pytest.raises(gimli._udunits2.UdunitsError):
         system[from_].to(system[to_])
         # system.Unit(from_).to(system.Unit(to_))
 
 
 # @pytest.mark.skip()
 def test_unit_converter_incompatible_units(system):
-    with pytest.raises(gimli.errors.IncompatibleUnitsError):
+    with pytest.raises(gimli._udunits2.UdunitsError):
         system.Unit("s").to(system.Unit("m"))
 
 

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -24,16 +24,16 @@ def system():
 def test_get_xml():
     os.environ.pop("UDUNITS2_XML_PATH", None)
     path, status = UnitSystem.get_xml_path()
-    assert path.is_file()
+    assert os.path.isfile(path)
     assert status == UnitStatus.OPEN_DEFAULT
 
     path, status = UnitSystem.get_xml_path(path)
-    assert path.is_file()
+    assert os.path.isfile(path)
     assert status == UnitStatus.OPEN_ARG
 
     os.environ["UDUNITS2_XML_PATH"] = str(path)
     path, status = UnitSystem.get_xml_path()
-    assert path.is_file()
+    assert os.path.isfile(path)
     assert status == UnitStatus.OPEN_ENV
 
 
@@ -41,26 +41,26 @@ def test_default_system():
     os.environ.pop("UDUNITS2_XML_PATH", None)
     system = UnitSystem()
     assert system.status == "default"
-    assert system.database.is_file()
+    assert os.path.isfile(system.database)
 
 
 def test_user_system():
     path = UnitSystem().database
     system = UnitSystem(path)
     assert system.status == "user"
-    assert system.database.is_file()
+    assert os.path.isfile(system.database)
     assert system == UnitSystem()
     assert UnitSystem(path) == UnitSystem(str(path))
 
 
 def test_env_system(system):
-    os.environ["UDUNITS2_XML_PATH"] = str(system.database)
+    os.environ["UDUNITS2_XML_PATH"] = system.database
     env_system = UnitSystem()
 
     assert env_system.status == "env"
-    assert env_system.database.is_file()
+    assert os.path.isfile(env_system.database)
     assert str(env_system) == str(system)
-    assert env_system.database.samefile(system.database)
+    assert os.path.samefile(system.database, env_system.database)
     assert env_system == system
 
 

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -12,6 +12,7 @@ import gimli
 from gimli._constants import UnitFormatting
 from gimli._constants import UnitStatus
 from gimli._system import UnitSystem
+from gimli._utils import get_xml_path
 from gimli.errors import UnitNameError
 
 
@@ -23,16 +24,16 @@ def system():
 
 def test_get_xml():
     os.environ.pop("UDUNITS2_XML_PATH", None)
-    path, status = UnitSystem.get_xml_path()
+    path, status = get_xml_path()
     assert os.path.isfile(path)
     assert status == UnitStatus.OPEN_DEFAULT
 
-    path, status = UnitSystem.get_xml_path(path)
+    path, status = get_xml_path(path)
     assert os.path.isfile(path)
     assert status == UnitStatus.OPEN_ARG
 
     os.environ["UDUNITS2_XML_PATH"] = str(path)
-    path, status = UnitSystem.get_xml_path()
+    path, status = get_xml_path()
     assert os.path.isfile(path)
     assert status == UnitStatus.OPEN_ENV
 
@@ -220,10 +221,11 @@ def test_unit_converter_same_units(system):
 )
 def test_unit_converter_bad_from_units(system, to_, from_):
     with pytest.raises(UnitNameError):
-        system.Unit(from_).to(system.Unit(to_))
+        system[from_].to(system[to_])
+        # system.Unit(from_).to(system.Unit(to_))
 
 
-@pytest.mark.skip()
+# @pytest.mark.skip()
 def test_unit_converter_incompatible_units(system):
     with pytest.raises(gimli.errors.IncompatibleUnitsError):
         system.Unit("s").to(system.Unit("m"))

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -9,10 +9,10 @@ from numpy.testing import assert_allclose
 from numpy.testing import assert_array_almost_equal
 
 import gimli
-from gimli import UnitFormatting
-from gimli import UnitNameError
-from gimli import UnitStatus
-from gimli import UnitSystem
+from gimli._constants import UnitFormatting
+from gimli._constants import UnitStatus
+from gimli._system import UnitSystem
+from gimli.errors import UnitNameError
 
 
 @pytest.fixture(scope="module")

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -13,7 +13,7 @@ from gimli._constants import UnitFormatting
 from gimli._constants import UnitStatus
 from gimli._system import UnitSystem
 from gimli._utils import get_xml_path
-from gimli.errors import UnitNameError
+from gimli.errors import DatabaseNotFoundError
 
 
 @pytest.fixture(scope="module")
@@ -36,6 +36,9 @@ def test_get_xml():
     path, status = get_xml_path()
     assert os.path.isfile(path)
     assert status == UnitStatus.OPEN_ENV
+
+    with pytest.raises(DatabaseNotFoundError):
+        get_xml_path("/path/to/nowhere")
 
 
 def test_default_system():


### PR DESCRIPTION
In this pull request, I've reorganized the *gimli* package.

* The preferred method for importing the *units* system is now ``from gimli.units import units``
* Added some new private modules, relocated stuff (mostly moving code out of *_udunits2.pyx*) that should not change the public API
* The units system now inherits from `Mapping`
* The `UnitSystem` is pre-loaded with some known units from the database
* Added *load_database* function that loads the *udunits2* xml files into a Python *dict*