### PR TITLE
Fix macos x86_64 wheels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,8 +133,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-latest]
+        python-version: ["3.12"]
 
     runs-on: ${{ matrix.os }}
 
@@ -144,12 +144,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Use Python
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Miniforge3
-          miniforge-version: latest
-          auto-update-conda: true
 
       - uses: actions/download-artifact@v4
         with:
@@ -160,10 +158,7 @@ jobs:
       - name: Test
         run: |
           pip install nox
-          nox -s test \
-              --verbose \
-              --force-pythons=${{ matrix.python-version }} \
-              -- dist
+          nox -s test --verbose -- dist
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,11 +49,11 @@ jobs:
 
           # Mac x86_64
           - cibw-only: "cp310-macosx_x86_64"
-            os: "macos-latest"
+            os: "macos-13"
           - cibw-only: "cp311-macosx_x86_64"
-            os: "macos-latest"
+            os: "macos-13"
           - cibw-only: "cp312-macosx_x86_64"
-            os: "macos-latest"
+            os: "macos-13"
 
           # Mac arm64
           - cibw-only: "cp310-macosx_arm64"
@@ -93,7 +93,7 @@ jobs:
         with:
           platforms: all
 
-      - name: Print build identifiers
+      - name: Build wheels
         run: |
           python -m pip install cibuildwheel
           python -m cibuildwheel --only ${{ matrix.cibw-only }} --print-build-identifiers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ test-requires = [
     "hypothesis",
     "pytest",
 ]
-# test-command = "pytest {package}/tests"
+test-command = "pytest {package}/tests"
 overrides = [
 	{ select = "*-musllinux*", before-all = "apk add flex libtool texinfo" },
 ]

--- a/src/gimli/_version.py
+++ b/src/gimli/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.3.dev0"
+__version__ = "0.3.3.dev1"


### PR DESCRIPTION
There is a problem with the wheels built for macos x86_64. Importing gimli.units, results in the following error,
```
symbol not found in flat namespace '_cv_convert_double'
```

Since the tests are run as part of the build process in *cibuildwheel*, I've turned off running the "test" job for everything except *linux* and Python 3.12. The only reason I left that one was to get code coverage.