### PR TITLE
Add builds for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
             os: "ubuntu-latest"
           - cibw-only: "cp312-manylinux_x86_64"
             os: "ubuntu-latest"
+          - cibw-only: "cp313-manylinux_x86_64"
+            os: "ubuntu-latest"
 
           # Linux aarch64
           - cibw-only: "cp310-manylinux_aarch64"
@@ -29,6 +31,8 @@ jobs:
           - cibw-only: "cp311-manylinux_aarch64"
             os: "ubuntu-latest"
           - cibw-only: "cp312-manylinux_aarch64"
+            os: "ubuntu-latest"
+          - cibw-only: "cp313-manylinux_aarch64"
             os: "ubuntu-latest"
 
           # musllinux x86_64
@@ -38,6 +42,8 @@ jobs:
             os: "ubuntu-latest"
           - cibw-only: "cp312-musllinux_x86_64"
             os: "ubuntu-latest"
+          - cibw-only: "cp313-musllinux_x86_64"
+            os: "ubuntu-latest"
 
           # musllinux aarch64
           - cibw-only: "cp310-musllinux_aarch64"
@@ -45,6 +51,8 @@ jobs:
           - cibw-only: "cp311-musllinux_aarch64"
             os: "ubuntu-latest"
           - cibw-only: "cp312-musllinux_aarch64"
+            os: "ubuntu-latest"
+          - cibw-only: "cp313-musllinux_aarch64"
             os: "ubuntu-latest"
 
           # Mac x86_64
@@ -54,6 +62,8 @@ jobs:
             os: "macos-13"
           - cibw-only: "cp312-macosx_x86_64"
             os: "macos-13"
+          - cibw-only: "cp313-macosx_x86_64"
+            os: "macos-13"
 
           # Mac arm64
           - cibw-only: "cp310-macosx_arm64"
@@ -62,6 +72,8 @@ jobs:
             os: "macos-latest"
           - cibw-only: "cp312-macosx_arm64"
             os: "macos-latest"
+          - cibw-only: "cp313-macosx_arm64"
+            os: "macos-latest"
 
           # Windows 64bit
           - cibw-only: "cp310-win_amd64"
@@ -69,6 +81,8 @@ jobs:
           - cibw-only: "cp311-win_amd64"
             os: "windows-latest"
           - cibw-only: "cp312-win_amd64"
+            os: "windows-latest"
+          - cibw-only: "cp313-win_amd64"
             os: "windows-latest"
 
           # Windows 32


### PR DESCRIPTION
This pull request add build for Python3.13. I've left the Python 3.10 builds in but will remove them when Python 3.13 is officially released.