### PR TITLE
Bump pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: extern
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.12.1
+  rev: 26.1.0
   hooks:
   - id: black
     name: black
@@ -14,7 +14,7 @@ repos:
     types_or: [python, pyi]
 
 - repo: https://github.com/pycqa/flake8
-  rev: 7.0.0
+  rev: 7.3.0
   hooks:
   - id: flake8
     additional_dependencies:
@@ -24,19 +24,19 @@ repos:
     args: [--max-line-length=88]
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.0
+  rev: v3.21.2
   hooks:
   - id: pyupgrade
     args: [--py310-plus]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.13.2
+  rev: 7.0.0
   hooks:
   - id: isort
     args: [--force-single-line-imports]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v6.0.0
   hooks:
     - id: check-builtin-literals
     - id: check-added-large-files
@@ -58,9 +58,8 @@ repos:
         )
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.8.0
+  rev: v1.19.1
   hooks:
   - id: mypy
     language_version: python3.12
-    additional_dependencies: [types-all]
     files: src/gimli/.*\.py$

--- a/src/gimli/_system.py
+++ b/src/gimli/_system.py
@@ -10,7 +10,6 @@ from gimli._utils import load_database
 
 
 class UnitSystem(Mapping[str, Unit], _UnitSystem):
-
     """A system of units.
 
     A unit-system is a set of units that are all defined in terms of
@@ -52,7 +51,7 @@ class UnitSystem(Mapping[str, Unit], _UnitSystem):
         else:
             return self.data[key]
 
-    def __iter__(self) -> Generator[str, None, None]:
+    def __iter__(self) -> Generator[str]:
         yield from self.data
 
     def __len__(self) -> int:


### PR DESCRIPTION
I've run `pre-commit autoupdate` to bump all of the versions of the *pre-commit* hooks. I've also removed a small bit of newly-found lint.