### PR TITLE
Fix cibuildwheel builds on mac x86_64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,43 +27,23 @@ jobs:
 
           # Linux aarch64
           - cibw-only: "cp310-manylinux_aarch64"
-            os: "ubuntu-latest"
+            os: "ubuntu-24.04-arm"
           - cibw-only: "cp311-manylinux_aarch64"
-            os: "ubuntu-latest"
+            os: "ubuntu-24.04-arm"
           - cibw-only: "cp312-manylinux_aarch64"
-            os: "ubuntu-latest"
+            os: "ubuntu-24.04-arm"
           - cibw-only: "cp313-manylinux_aarch64"
-            os: "ubuntu-latest"
-
-          # musllinux x86_64
-          - cibw-only: "cp310-musllinux_x86_64"
-            os: "ubuntu-latest"
-          - cibw-only: "cp311-musllinux_x86_64"
-            os: "ubuntu-latest"
-          - cibw-only: "cp312-musllinux_x86_64"
-            os: "ubuntu-latest"
-          - cibw-only: "cp313-musllinux_x86_64"
-            os: "ubuntu-latest"
-
-          # musllinux aarch64
-          - cibw-only: "cp310-musllinux_aarch64"
-            os: "ubuntu-latest"
-          - cibw-only: "cp311-musllinux_aarch64"
-            os: "ubuntu-latest"
-          - cibw-only: "cp312-musllinux_aarch64"
-            os: "ubuntu-latest"
-          - cibw-only: "cp313-musllinux_aarch64"
-            os: "ubuntu-latest"
+            os: "ubuntu-24.04-arm"
 
           # Mac x86_64
           - cibw-only: "cp310-macosx_x86_64"
-            os: "macos-13"
+            os: "macos-15-intel"
           - cibw-only: "cp311-macosx_x86_64"
-            os: "macos-13"
+            os: "macos-15-intel"
           - cibw-only: "cp312-macosx_x86_64"
-            os: "macos-13"
+            os: "macos-15-intel"
           - cibw-only: "cp313-macosx_x86_64"
-            os: "macos-13"
+            os: "macos-15-intel"
 
           # Mac arm64
           - cibw-only: "cp310-macosx_arm64"
@@ -94,18 +74,12 @@ jobs:
           #   os: "windows-latest"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Use Python 3.10
-        uses: actions/setup-python@v5
+      - name: Use Python 3.14
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
-
-      - name: Set up QEMU  # Needed to build aarch64 wheels
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
+          python-version: '3.14'
 
       - name: Build wheels
         run: |
@@ -113,14 +87,14 @@ jobs:
           python -m cibuildwheel --only ${{ matrix.cibw-only }} --print-build-identifiers
 
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2.0.2
+        uses: jwlawson/actions-setup-cmake@v2.1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.2
+        uses: pypa/cibuildwheel@v3.3
         with:
           only: ${{ matrix.cibw-only }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: wheel-${{ matrix.os }}-${{ matrix.cibw-only }}
           path: ./wheelhouse/*.whl
@@ -130,7 +104,7 @@ jobs:
     name: "Show artifacts"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
       with:
         pattern: "wheel-*"
         merge-multiple: true
@@ -157,13 +131,13 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: "wheel-*"
           merge-multiple: true
@@ -223,7 +197,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: "wheel-*"
           merge-multiple: true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 0.3.4 (unreleased)
 
-- Nothing changed yet.
+- Fixed cibuildwheel builds for *macos* *x86_64*.
 
 ## 0.3.3 (2024-10-04)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,13 +88,15 @@ where = [
 
 [tool.cibuildwheel]
 build = "cp310-* cp311-* cp312-*"
-skip = "*-win32*"
-archs = "x86_64,aarch64,arm64,AMD64,x86"
+skip = "*-win32* *-manylinux_i686* *-musllinux_i686*"
+environment = """
+UDUNITS2_PREFIX="$(pwd -P)/dist/extern"
+"""
 before-build = [
     "cd extern/udunits-2.2.28",
     "mkdir -p m4",
     "autoreconf -fvi",
-    "./configure --disable-static --enable-shared --prefix=/usr/local",
+    "./configure --disable-static --enable-shared --prefix=$UDUNITS2_PREFIX",
     "make",
     "make install",
 ]
@@ -103,22 +105,16 @@ test-requires = [
     "pytest",
 ]
 test-command = "pytest {package}/tests"
-overrides = [
-	{ select = "*-musllinux*", before-all = "apk add flex libtool texinfo" },
-]
 
 [tool.cibuildwheel.linux]
+archs = "x86_64,aarch64"
 before-all = "yum install -y flex libtool texinfo"
+repair-wheel-command = """
+LD_LIBRARY_PATH="$UDUNITS2_PREFIX/lib:${LD_LIBRARY_PATH:-}" auditwheel repair -w {dest_dir} {wheel}
+"""
 
 [tool.cibuildwheel.macos]
-before-build = [
-    "cd extern/udunits-2.2.28",
-    "mkdir -p m4",
-    "autoreconf -fvi",
-    "./configure --disable-static --enable-shared --prefix=/usr/local",
-    "make",
-    "sudo make install",
-]
+archs = "x86_64,arm64"
 before-all = "brew install automake libtool texinfo"
 
 [tool.cibuildwheel.windows]

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import numpy
 from setuptools import Extension
 from setuptools import setup
 
-udunits2_prefix = os.environ.get("WITH_UDUNITS2", sys.prefix)
-if sys.platform.startswith("win") and "WITH_UDUNITS" not in os.environ:
+udunits2_prefix = os.environ.get("UDUNITS2_PREFIX", sys.prefix)
+if sys.platform.startswith("win") and "UDUNITS2_PREFIX" not in os.environ:
     udunits2_prefix = os.path.join(sys.prefix, "Library")
 vendored_prefix = os.path.join(os.path.dirname(__file__), "dist", "extern")
 


### PR DESCRIPTION
The builds using *cibuildwheel* were broken for *Mac* *x86_64*, so I've fixed them and also cleaned them up along with the *Linux* builds.