### PR TITLE
Run the tests with coverage command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## 0.3.4 (unreleased)
 
 - Fixed cibuildwheel builds for *macos* *x86_64*.
+- Fixed failing tests by using *coverage* directly instead of *pytest-cov*.
+  This fixed tests that failed with double import of *numpy* errors.
 
 ## 0.3.3 (2024-10-04)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,14 +32,11 @@ def test(session: nox.Session) -> None:
         *("-r", "requirements-testing.in"),
     )
 
-    args = ["--cov", "gimli.units", "-vvv"]
-
-    if "CI" in os.environ:
-        args.append(f"--cov-report=xml:{ROOT.absolute()!s}/coverage.xml")
-    session.run("pytest", *args)
-
-    if "CI" not in os.environ:
-        session.run("coverage", "report", "--ignore-errors", "--show-missing")
+    session.run(
+        "coverage", "run", "--source=gimli,tests", "--branch", "--module", "pytest"
+    )
+    session.run("coverage", "report", "--ignore-errors", "--show-missing")
+    session.run("coverage", "xml", "-o", "coverage.xml")
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ dev = [
     "nox",
 ]
 testing = [
+    "coverage",
     "hypothesis",
     "pytest",
-    "pytest-cov",
 ]
 
 [project.urls]

--- a/requirements-testing.in
+++ b/requirements-testing.in
@@ -1,3 +1,3 @@
+coverage
 hypothesis
 pytest
-pytest-cov


### PR DESCRIPTION
I've changed the *nox* session that runs the tests to run them using *coverage* directly rather than the *pytest* plugin, *pytest-cov*. Using *pytest-cov* caused errors when collecting the tests that complained about trying to import *numpy* twice. I'm not totally sure what that was all about but dropping the extension fixed things and using *coverage* directly seems more straightforward, anyway.