### PR TITLE
Use richcmp in cython for comparing Units

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Fixed a bug in the error string for a bad encoding value in the unit formatter.
 - Changed error to `IncompatibleUnitsError` when trying to convert between
   units that are not compatible with one another.
+- Implemented `__richcmp__` in *cython* for for unit comparisons with `Units`.
 
 ## 0.3.3 (2024-10-04)
 

--- a/src/gimli/_udunits2.pyx
+++ b/src/gimli/_udunits2.pyx
@@ -7,6 +7,12 @@ import sys
 import numpy as np
 
 cimport numpy as np
+from cpython.object cimport Py_EQ
+from cpython.object cimport Py_GE
+from cpython.object cimport Py_GT
+from cpython.object cimport Py_LE
+from cpython.object cimport Py_LT
+from cpython.object cimport Py_NE
 from libc.stdlib cimport free
 from libc.stdlib cimport malloc
 from libc.string cimport strcpy
@@ -289,23 +295,23 @@ cdef class Unit:
         """
         return ut_compare(self._unit, other._unit)
 
-    def __lt__(self, other):
-        return self.compare(other) < 0
-
-    def __le__(self, other):
-        return self.compare(other) <= 0
-
-    def __eq__(self, other):
-        return self.compare(other) == 0
-
-    def __ge__(self, other):
-        return self.compare(other) >= 0
-
-    def __gt__(self, other):
-        return self.compare(other) > 0
-
-    def __ne__(self, other):
-        return self.compare(other) != 0
+    def __richcmp__(self, other, int op):
+        if not isinstance(other, Unit):
+            return NotImplemented
+        cdef int c = ut_compare(self._unit, (<Unit>other)._unit)
+        if op == Py_LT:
+            return c < 0
+        if op == Py_LE:
+            return c <= 0
+        if op == Py_EQ:
+            return c == 0
+        if op == Py_NE:
+            return c != 0
+        if op == Py_GT:
+            return c > 0
+        if op == Py_GE:
+            return c >= 0
+        return NotImplemented
 
     def __hash__(self):
         return hash(self.format(encoding="ascii", formatting=UnitFormatting.NAMES))

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -1,3 +1,4 @@
+import operator
 import os
 import random
 
@@ -150,21 +151,34 @@ def test_unit_formatting_bad_encoding(system, encoding):
 @pytest.mark.parametrize(
     ("lhs", "cmp_", "rhs"),
     [
-        ("m", "lt", "km"),
-        ("m", "le", "km"),
-        ("m", "le", "m"),
-        ("m", "eq", "m"),
-        ("m", "ne", "km"),
-        ("km", "ge", "m"),
-        ("km", "ge", "km"),
-        ("km", "gt", "m"),
+        ("m", operator.lt, "km"),
+        ("m", operator.le, "km"),
+        ("m", operator.le, "m"),
+        ("m", operator.eq, "m"),
+        ("m", operator.ne, "km"),
+        ("km", operator.ge, "m"),
+        ("km", operator.ge, "km"),
+        ("km", operator.gt, "m"),
     ],
 )
 def test_unit_comparisons(system, lhs, cmp_, rhs):
-    compare = getattr(system.Unit(lhs), f"__{cmp_}__")
-    assert compare(system.Unit(rhs))
+    assert cmp_(system.Unit(lhs), system.Unit(rhs))
+
+
+@pytest.mark.parametrize(
+    ("lhs", "cmp_", "rhs"),
+    [
+        ("m", operator.lt, "km"),
+        ("m", operator.le, "km"),
+        ("m", operator.le, "m"),
+        ("km", operator.ge, "m"),
+        ("km", operator.ge, "km"),
+        ("km", operator.gt, "m"),
+    ],
+)
+def test_unit_str_comparisons(system, lhs, cmp_, rhs):
     with pytest.raises(TypeError):
-        compare(rhs)
+        cmp_(system.Unit(lhs), rhs)
 
 
 def test_unit_is_hashable(system):
@@ -176,8 +190,8 @@ def test_unit_is_hashable(system):
 
     d = {a: 1}
     assert d[a] == 1
-    assert a in set([a])
-    assert b in set([a])
+    assert a in {a}
+    assert b in {a}
 
 
 def test_unit_symbol(system):


### PR DESCRIPTION
I've modified the *cython* Unit class to use `__richcmp__` for comparisons.