### PR TITLE
Release the GIL before calling converters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   This fixed tests that failed with double import of *numpy* errors.
 - Added tests for Python 3.10, 3.11, 3.12, 3.13, and 3.14 on the latest versions
   of *Linux*, *Mac*, and *Windows*.
+- Added `nogil` blocks to the unit converters for speed imrovements for large
+  arrays.
 
 ## 0.3.3 (2024-10-04)
 


### PR DESCRIPTION
I've wrapped the calls to the C functions that do the unit conversion in `nogil` blocks. Releasing the GIL for these calls should help speed things up for large arrays. There's probably no gain to be had by releasing the GIL for the call to `cv_convert_double` (i.e. just converting a scalar) but I've added it just for symmetry. If it proves to add noticeable overhead, I'll remove it.