### PR TITLE
Add checks for NULL pointers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
   of *Linux*, *Mac*, and *Windows*.
 - Added `nogil` blocks to the unit converters for speed imrovements for large
   arrays.
+- Added `NULL` checks to prevent possible segmentation faults.
 
 ## 0.3.3 (2024-10-04)
 

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -254,6 +254,23 @@ def test_unit_converter_double_array(system, shape, dtype):
     assert values_in_km.dtype == dtype
 
 
+@pytest.mark.parametrize("dtype", (np.single, np.double))
+def test_unit_converter_empty_array(system, dtype):
+    values = np.asarray([], dtype=dtype)
+
+    meters = system.Unit("m")
+    km = system.Unit("km")
+
+    m_to_km = meters.to(km)
+    actual = m_to_km(values)
+    assert actual.size == 0
+    assert actual.dtype == dtype
+
+    out = np.empty_like(values)
+    actual = m_to_km(values, out=out)
+    assert actual is out
+
+
 @given(
     src_values=hynp.arrays(
         dtype=hynp.floating_dtypes(),


### PR DESCRIPTION
I've added some checks to ensure we don't call *udunits* functions will NULL pointers that would result in segmentation faults.