### PR TITLE
Make Units hashable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Added `nogil` blocks to the unit converters for speed imrovements for large
   arrays.
 - Added `NULL` checks to prevent possible segmentation faults.
+- Implemented `__hash__` for `Units`.
 
 ## 0.3.3 (2024-10-04)
 

--- a/src/gimli/_udunits2.pyx
+++ b/src/gimli/_udunits2.pyx
@@ -306,6 +306,9 @@ cdef class Unit:
     def __ne__(self, other):
         return self.compare(other) != 0
 
+    def __hash__(self):
+        return hash(self.format(encoding="ascii", formatting=UnitFormatting.NAMES))
+
     def format(self, encoding="ascii", formatting=UnitFormatting.NAMES):
         try:
             unit_encoding = UDUNITS_ENCODING[encoding]

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -160,6 +160,19 @@ def test_unit_comparisons(system, lhs, cmp_, rhs):
         compare(rhs)
 
 
+def test_unit_is_hashable(system):
+    a = system.Unit("m")
+    b = system.Unit("meter")
+
+    if a == b:
+        assert hash(a) == hash(b)
+
+    d = {a: 1}
+    assert d[a] == 1
+    assert a in set([a])
+    assert b in set([a])
+
+
 def test_unit_symbol(system):
     meters = system.Unit("m")
     assert meters.symbol == "m"


### PR DESCRIPTION
I've implemented the `__hash__` method for `Units` so that it can be hashed. The hash is based on a normalized unit string.