### PR TITLE
Fix bug in the error message for bad encoding value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
   arrays.
 - Added `NULL` checks to prevent possible segmentation faults.
 - Implemented `__hash__` for `Units`.
+- Fixed a bug in the error string for a bad encoding value in the unit formatter.
 
 ## 0.3.3 (2024-10-04)
 

--- a/src/gimli/_udunits2.pyx
+++ b/src/gimli/_udunits2.pyx
@@ -313,7 +313,7 @@ cdef class Unit:
         try:
             unit_encoding = UDUNITS_ENCODING[encoding]
         except KeyError:
-            raise ValueError("unknown encoding ({encoding})")
+            raise ValueError(f"unknown encoding ({encoding!r})")
 
         str_len = ut_format(
             self._unit, self._buffer, 2048, opts=unit_encoding | formatting

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -140,6 +140,13 @@ def test_unit_formatting(system):
     )
 
 
+@pytest.mark.parametrize("encoding", ("", "bad-encoding-name", None))
+def test_unit_formatting_bad_encoding(system, encoding):
+    unit = system.Unit("0.1 lg(re m/(5 s)^2) @ 50")
+    with pytest.raises(ValueError, match="unknown encoding"):
+        unit.format(encoding=encoding)
+
+
 @pytest.mark.parametrize(
     ("lhs", "cmp_", "rhs"),
     [


### PR DESCRIPTION
The error string used for a unknown encoding value was not an f-string, but should have been so I fixed that and added a unit test.