### PR TITLE
Raise IncompatibleUnitsError when converting between incompatible units

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 - Added `NULL` checks to prevent possible segmentation faults.
 - Implemented `__hash__` for `Units`.
 - Fixed a bug in the error string for a bad encoding value in the unit formatter.
+- Changed error to `IncompatibleUnitsError` when trying to convert between
+  units that are not compatible with one another.
 
 ## 0.3.3 (2024-10-04)
 

--- a/src/gimli/_udunits2.pyx
+++ b/src/gimli/_udunits2.pyx
@@ -249,13 +249,14 @@ cdef class Unit:
         return self.UnitConverter(unit)
 
     cpdef UnitConverter(self, Unit unit):
+        if not ut_are_convertible(self._unit, unit._unit):
+            raise IncompatibleUnitsError(str(self), str(unit))
+
         with suppress_stdout():
             converter = ut_get_converter(self._unit, unit._unit)
 
         if converter == NULL:
-            status = ut_get_status()
-            raise UdunitsError(status)
-            # raise IncompatibleUnitsError(str(self), str(unit))
+            raise UdunitsError(ut_get_status())
 
         return UnitConverter.from_ptr(converter, owner=True)
 

--- a/tests/units_test.py
+++ b/tests/units_test.py
@@ -250,7 +250,7 @@ def test_unit_converter_bad_from_units(system, to_, from_):
 
 # @pytest.mark.skip()
 def test_unit_converter_incompatible_units(system):
-    with pytest.raises(gimli._udunits2.UdunitsError):
+    with pytest.raises(gimli.errors.IncompatibleUnitsError):
         system.Unit("s").to(system.Unit("m"))
 
 


### PR DESCRIPTION
I've modified the unit converter to raise a `IncompatibleUnitsError` if trying to convert between units that are incompatible. Before, a general `UdunitsError` was raised.