### PR TITLE
Ensure the correct python version for test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Coverage
         run: |
           pip install nox
-          nox -s coverage --verbose
+          nox -s coverage --force-pythons=${{ matrix.python-version }} --verbose
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 - Added a *coverage* session to the *nox* file that runs coverage on an editable
   install rather than on a wheel.
 - Replaced *coveralls* with *Codecov* in the CI.
+- Fixed an issue that caused all of the CI tests to run with the same python
+  version.
 
 ## 0.3.3 (2024-10-04)
 


### PR DESCRIPTION
All the coverage tests were being run with the same python version despite what was installed with `actions/setup-python` so I've forced the python version *nox* finds by using `--force-pythons`.