### PR TITLE
Run coverage on an editable install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,8 +93,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest]
+        python-version: ["3.14"]
 
     runs-on: ${{ matrix.os }}
 
@@ -109,16 +109,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/download-artifact@v7
-        with:
-          pattern: "wheel-*"
-          merge-multiple: true
-          path: ${{ github.workspace }}/dist
+      - name: Install udunits2
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudunits2-dev udunits-bin pkg-config
 
       - name: Test
         run: |
           pip install nox
-          nox -s test --verbose -- dist
+          nox -s coverage --verbose
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
 - Changed error to `IncompatibleUnitsError` when trying to convert between
   units that are not compatible with one another.
 - Implemented `__richcmp__` in *cython* for for unit comparisons with `Units`.
+- Added a *coverage* session to the *nox* file that runs coverage on an editable
+  install rather than on a wheel.
 
 ## 0.3.3 (2024-10-04)
 


### PR DESCRIPTION
I've changed the coverage step to run on an editable install rather than on built wheels. This should make coverage easier by ensuring the source files are looked at for coverage rather than the installed files. I've also reduced the coverage to only be run on *Linux* and Python 3.14.