### PR TITLE
Build gimli wheels using static libraries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
   version.
 - Changed the CI to publish to PyPI/TestPyPI when the workflow is manually
   triggered rather than looking for a tag.
+- Link to static libraries when building wheels.
 
 ## 0.3.3 (2024-10-04)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,19 +85,39 @@ where = [
 ]
 
 [tool.cibuildwheel]
-build = "cp310-* cp311-* cp312-*"
-skip = "*-win32* *-manylinux_i686* *-musllinux_i686*"
+build = [
+  "cp310-*",
+  "cp311-*",
+  "cp312-*",
+]
+skip = [
+  "*-win32*",
+  "*-manylinux_i686*",
+  "*-musllinux_i686*",
+]
 environment = """
 UDUNITS2_PREFIX="$(pwd -P)/dist/extern"
 """
-before-build = [
-    "cd extern/udunits-2.2.28",
-    "mkdir -p m4",
-    "autoreconf -fvi",
-    "./configure --disable-static --enable-shared --prefix=$UDUNITS2_PREFIX",
-    "make",
-    "make install",
-]
+before-build = """
+cmake -S extern/expat-2.6.0 -B build/expat \
+  -DCMAKE_INSTALL_PREFIX="$UDUNITS2_PREFIX" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+cmake --build build/expat --config Release
+cmake --install build/expat --config Release
+cmake -S extern/udunits-2.2.28 -B build/udunits2 \
+  -DCMAKE_INSTALL_PREFIX="$UDUNITS2_PREFIX" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DEXPAT_INCLUDE_DIR="$UDUNITS2_PREFIX/include" \
+  -DEXPAT_LIBRARY="$UDUNITS2_PREFIX/lib/libexpat.a"
+cmake --build build/udunits2 --config Release
+cmake --install build/udunits2 --config Release
+"""
 test-requires = [
     "hypothesis",
     "pytest",
@@ -105,19 +125,18 @@ test-requires = [
 test-command = "pytest {package}/tests"
 
 [tool.cibuildwheel.linux]
-archs = "x86_64,aarch64"
-before-all = "yum install -y flex libtool texinfo"
-repair-wheel-command = """
-LD_LIBRARY_PATH="$UDUNITS2_PREFIX/lib:${LD_LIBRARY_PATH:-}" auditwheel repair -w {dest_dir} {wheel}
-"""
+archs = [
+  "x86_64",
+  "aarch64",
+]
 
 [tool.cibuildwheel.macos]
-archs = "x86_64,arm64"
-before-all = "brew install automake libtool texinfo"
+archs = ["x86_64", "arm64"]
 
 [tool.cibuildwheel.windows]
-before-build = "pip install delvewheel"
-before-all = [
+environment = { UDUNITS2_PREFIX = "$(cygpath -w \"$(pwd)/dist/extern\")" }
+before-all = "pip install delvewheel"
+before-build = [
     "cd {package}\\extern\\expat-2.6.0",
     "cmake -S . -DCMAKE_INSTALL_PREFIX={package}\\dist\\extern",
     "cmake --build . --config Release",

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,44 @@
 import os
+import pathlib
 import sys
 
 import numpy
 from setuptools import Extension
 from setuptools import setup
 
-udunits2_prefix = os.environ.get("UDUNITS2_PREFIX", sys.prefix)
-if sys.platform.startswith("win") and "UDUNITS2_PREFIX" not in os.environ:
-    udunits2_prefix = os.path.join(sys.prefix, "Library")
-vendored_prefix = os.path.join(os.path.dirname(__file__), "dist", "extern")
+is_windows = sys.platform.startswith("win")
+is_macos = sys.platform == "darwin"
+is_linux = sys.platform.startswith("linux")
+
+if is_windows:
+    lib_ext = ".lib"
+    static_libs = (f"udunits2{lib_ext}", f"libexpat{lib_ext}")
+else:
+    lib_ext = ".a"
+    static_libs = (f"libudunits2{lib_ext}", f"libexpat{lib_ext}")
+
+include_dirs = [numpy.get_include()]
+library_dirs = []
+libraries = []
+extra_objects = []
+extra_compile_args = []
+
+udunits2_prefix = os.environ.get("UDUNITS2_PREFIX")
+
+if udunits2_prefix is not None:
+    udunits2_prefix = pathlib.Path(udunits2_prefix)
+
+    libdir = udunits2_prefix / "lib"
+    incdir = udunits2_prefix / "include"
+
+    extra_objects += [
+        str(libdir / lib) for lib in static_libs if (libdir / lib).is_file()
+    ]
+
+    library_dirs += [str(libdir)] if libdir.is_dir() else []
+    include_dirs += [str(incdir)] if incdir.is_dir() else []
+else:
+    libraries += ["udunits2", "expat"]
 
 setup(
     include_package_data=True,
@@ -16,16 +46,11 @@ setup(
         Extension(
             "gimli._udunits2",
             ["src/gimli/_udunits2.pyx"],
-            libraries=["udunits2"],
-            include_dirs=[
-                numpy.get_include(),
-                os.path.join(udunits2_prefix, "include"),
-                os.path.join(vendored_prefix, "include"),
-            ],
-            library_dirs=[
-                os.path.join(udunits2_prefix, "lib"),
-                os.path.join(vendored_prefix, "lib"),
-            ],
+            libraries=libraries,
+            extra_objects=extra_objects,
+            include_dirs=include_dirs,
+            library_dirs=library_dirs,
+            extra_compile_args=extra_compile_args,
         )
     ],
 )


### PR DESCRIPTION
I've modified `setup.py` and the *cibuildwheel* sections of `pyproject.toml` to create wheels that link to static libraries for both *udunits2* and *expat*. This should create wheels that are more robust because there isn't any linking to shared libraries at runtime.
