### PR TITLE
Add new api functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
   triggered rather than looking for a tag.
 - Link to static libraries when building wheels.
 - Removed deprecated ``FileType`` *argparse* types from the *cli*.
+- Added new api functions ``convert``, ``make_converter``, and ``get_unit_system``.
 
 ## 0.3.3 (2024-10-04)
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,34 @@ which can be found in the `extern` folder of this repository).
 
 ## Usage
 
-Primarily, *gimli.units* is a Python module with an [API](#API) that reflects that of
-the *udunits2* library. *gimli*, however, also comes with a
-[command-line interface](#command-line-interface).
+### Quick conversions
 
-# API
+Use `gimli.convert` to convert scalars or arrays between unit strings:
+
+```python
+>>> from gimli import convert
+
+>>> convert(10.0, "N", "lb.ft/s2")
+72.33013851209893
+>>> convert([0.0, 250.0, 1000.0], "N", "lb*ft/s^2")
+array([   0.        , 1808.2534628 , 7233.01385121])
+```
+
+### Reuse converters
+
+If you will apply the same conversion many times, build a converter once:
+
+```python
+>>> from gimli import make_converter
+
+>>> m_to_ft = make_converter("m", "ft")
+>>> m_to_ft([0.0, 1.0, 2.0])
+array([0.        , 3.2808399 , 6.56167979])
+>>> m_to_ft(3.0)
+9.842519685039369
+```
+
+### Unit Systems
 
 You primarily will access *gimli* through *gimli.units*,
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ warn_unused_ignores = true
 [tool.pytest.ini_options]
 minversion = "6.0.0rc1"
 testpaths = [
-    "tests",
+    "src/gimli", "tests",
 ]
 norecursedirs = [
     ".*",
@@ -179,8 +179,6 @@ norecursedirs = [
     "dist",
 ]
 addopts = [
-    "--ignore=bmi_tester/bootstrap",
-    "--ignore=bmi_tester/tests",
     "--tb=native",
     "--strict-markers",
     "--durations=16",

--- a/src/gimli/__init__.py
+++ b/src/gimli/__init__.py
@@ -1,5 +1,13 @@
-# from gimli._system import UnitSystem
+from gimli._api import convert
+from gimli._api import get_unit_system
+from gimli._api import make_converter
 from gimli._version import __version__
 from gimli.units import units
 
-__all__ = ["__version__", "units"]
+__all__ = [
+    "__version__",
+    "convert",
+    "get_unit_system",
+    "make_converter",
+    "units",
+]

--- a/src/gimli/_api.py
+++ b/src/gimli/_api.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import os
+
+import numpy as np
+from numpy.typing import ArrayLike
+from numpy.typing import NDArray
+
+from gimli._system import UnitSystem
+from gimli._utils import get_xml_path
+
+
+_UNIT_SYSTEM_CACHE: dict[str, UnitSystem] = {}
+
+
+def make_converter(src: str, dst: str, system: UnitSystem | None = None) -> Converter:
+    """Create a callable converter between two units.
+
+    Parameters
+    ----------
+    src: str
+        Source unit string (e.g., ``"m"``, ``"Pa"``, ``"degC"``).
+    dst: str
+        Destination unit string (e.g., ``"km"``, ``"bar"``, ``"K"``).
+    system: UnitSystem, optional
+        Optional ``UnitSystem`` instance to use. If ``None``, uses the
+        cached global unit system returned by ``get_unit_system``.
+
+    Returns
+    -------
+    converter: Converter
+        A callable object that converts values from *src* to *dst*.
+
+    Examples
+    --------
+    >>> c = make_converter("degC", "K")
+    >>> c(0.0)
+    273.15
+    """
+    if system is None:
+        _system = get_unit_system()
+    else:
+        _system = system
+
+    src_units = _system.Unit(src)
+    dst_units = _system.Unit(dst)
+    src_to_dst = src_units.to(dst_units)
+
+    offset = src_to_dst(0.0)
+    scale = src_to_dst(1.0) - offset
+
+    return Converter(src, dst, scale=scale, offset=offset)
+
+
+def convert(
+    values: ArrayLike, from_: str, to: str, system: UnitSystem | None = None
+) -> float | NDArray[np.floating]:
+    """Convert values from one unit to another.
+
+    This is a convenience wrapper around ``make_converter``. It creates a
+    converter and immediately applies it to *values*.
+
+    Parameters
+    ----------
+    values: array_like
+        Scalar or array-like of numeric values to convert.
+    from_: str
+        Source unit string (e.g., ``"m"``, ``"km"``, ``"degC"``).
+    to: str
+        Destination unit string (e.g., ``"ft"``, ``"s"``, ``"K"``).
+    system: UnitSystem, optional
+        Optional :class:`~gimli.UnitSystem` instance to use for parsing and
+        conversion. If *None*, uses the cached global unit system returned by
+        :func:`get_unit_system`.
+
+    Returns
+    -------
+    array_like
+        Converted values.
+
+    Examples
+    --------
+    Convert a scalar:
+
+    >>> convert(10.0, "m", "ft")
+    32.80839895013123
+
+    Convert an array:
+
+    >>> convert([0.0, 1000.0], "m", "km")
+    array([0., 1.])
+    """
+    converter = make_converter(from_, to, system=system)
+    return converter(values)
+
+
+def get_unit_system(filepath: str | None = None) -> UnitSystem:
+    """Get a cached unit system instance.
+
+    This function loads and caches a ``UnitSystem`` keyed by the
+    canonical path to the UDUNITS XML database. Repeated calls for the same XML
+    path return the same ``UnitSystem`` instance.
+
+    Parameters
+    ----------
+    filepath: str, optional
+        Path used to locate the UDUNITS XML database. If not provided, return
+        the default unit system.
+
+    Returns
+    -------
+    UnitSystem
+        The unit system associated with the database path.
+
+    Notes
+    -----
+    Caching is performed in-process. If you need to isolate unit definitions
+    (e.g., for tests), consider constructing a dedicated ``UnitSystem``.
+
+    Examples
+    --------
+    >>> usys = get_unit_system()
+    >>> usys.Unit("m")
+    Unit('meter')
+    """
+    path_to_xml, _ = get_xml_path(filepath)
+
+    canonical_path = _canonicalize_path(path_to_xml)
+
+    if canonical_path not in _UNIT_SYSTEM_CACHE:
+        _UNIT_SYSTEM_CACHE[canonical_path] = UnitSystem(canonical_path)
+    return _UNIT_SYSTEM_CACHE[canonical_path]
+
+
+class Converter:
+    """Convert units."""
+
+    __slots__ = ("source", "destination", "scale", "offset")
+
+    def __init__(
+        self,
+        src: str,
+        dst: str,
+        *,
+        scale: float,
+        offset: float,
+    ) -> None:
+        self.source = src
+        self.destination = dst
+        self.scale = float(scale)
+        self.offset = float(offset)
+
+    def __call__(self, values: ArrayLike) -> float | NDArray:
+        """Convert values from source to destination units."""
+        if np.isscalar(values):
+            return self.scale * float(values) + self.offset
+
+        arr = np.asarray(values)
+        return arr * self.scale + self.offset
+
+    def __repr__(self) -> str:
+        args = (
+            repr(self.source),
+            repr(self.destination),
+            f"scale={self.scale!r}",
+            f"offset={self.offset!r}",
+        )
+        return f"Converter({', '.join(args)})"
+
+
+def _canonicalize_path(path: str) -> str:
+    return os.path.normcase(os.path.abspath(os.path.normpath(path)))

--- a/src/gimli/units.py
+++ b/src/gimli/units.py
@@ -1,3 +1,3 @@
-from gimli._system import UnitSystem
+from gimli._api import get_unit_system
 
-units = UnitSystem()
+units = get_unit_system()

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1,0 +1,62 @@
+import pytest
+from numpy.testing import assert_almost_equal
+
+from gimli._api import Converter
+from gimli._api import convert
+from gimli._api import get_unit_system
+from gimli._api import make_converter
+from gimli._system import UnitSystem
+
+
+def test_convert():
+    expected = 0.01
+    actual = convert(10.0, "m", "km")
+    assert actual == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "unit_a, unit_b",
+    (("m", "km"), ("km", "m"), ("nm", "parsec"), ("degC", "degF"), ("degK", "degC")),
+)
+def test_convert_repr(unit_a, unit_b):
+    converter_a = make_converter(unit_a, unit_b)
+    converter_b = eval(repr(converter_a), {"Converter": Converter})
+
+    assert converter_a(53.0) == pytest.approx(converter_b(53.0))
+
+
+@pytest.mark.parametrize("value", (53.0, 0.0, -1.0, [4, 6]))
+def test_convert_round_trip(value):
+    assert convert(convert(value, "km", "m"), "m", "km") == pytest.approx(value)
+
+
+def test_make_converter():
+    c = make_converter("m", "km")
+    assert c(10.0) == pytest.approx(0.01)
+
+
+@pytest.mark.parametrize("value", (53.0, 0.0, -1.0, [4, 6]))
+@pytest.mark.parametrize(
+    "unit_a, unit_b",
+    (("m", "km"), ("km", "m"), ("nm", "parsec"), ("degC", "degF"), ("degK", "degC")),
+)
+def test_make_converter_round_trip(value, unit_a, unit_b):
+    m_to_km = make_converter(unit_a, unit_b)
+    km_to_m = make_converter(unit_b, unit_a)
+    assert_almost_equal(km_to_m(m_to_km(value)), value)
+
+
+def test_make_converter_with_unit_system():
+    m_to_km = make_converter("m", "km", system=UnitSystem())
+    assert m_to_km("1000.0") == pytest.approx(1.0)
+
+
+def test_get_unit_system():
+    unit_system = get_unit_system()
+    assert "m" in unit_system
+
+
+def test_get_unit_system_singleton():
+    system_a = get_unit_system()
+    system_b = get_unit_system()
+    assert system_a is system_b


### PR DESCRIPTION
I've added three new functions to the api:
* `convert`: convert a value from one unit to another
* `make_converter`: create converters given source and destination units
* `get_unit_system`: get a unit system by path name (or the default system if no path is given). Caches the results.