### PR TITLE
Remove deprecated FileType from argparse options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 - Changed the CI to publish to PyPI/TestPyPI when the workflow is manually
   triggered rather than looking for a tag.
 - Link to static libraries when building wheels.
+- Removed deprecated ``FileType`` *argparse* types from the *cli*.
 
 ## 0.3.3 (2024-10-04)
 

--- a/src/gimli/_main.py
+++ b/src/gimli/_main.py
@@ -33,7 +33,7 @@ def main(argv: tuple[str, ...] | None = None) -> int:
         action="store_true",
         help="Also emit status messages to stderr.",
     )
-    parser.add_argument("file", type=argparse.FileType("rb"), nargs="*")
+    parser.add_argument("file", nargs="*")
     parser.add_argument(
         *("-f", "--from"),
         dest="from_",
@@ -49,9 +49,7 @@ def main(argv: tuple[str, ...] | None = None) -> int:
         default=system.Unit("1"),
         help="Destination units.",
     )
-    parser.add_argument(
-        "-o", "--output", type=argparse.FileType("w"), default=sys.stdout
-    )
+    parser.add_argument("-o", "--output", default=sys.stdout)
 
     args = parser.parse_args(argv)
 
@@ -73,7 +71,7 @@ def main(argv: tuple[str, ...] | None = None) -> int:
 
     for name in args.file:
         if args.verbose and not args.quiet:
-            out(f"[info] reading {name.name}")
+            out(f"[info] reading {name}")
         array = np.loadtxt(name, delimiter=",")
         np.savetxt(
             args.output,

--- a/src/gimli/_utils.py
+++ b/src/gimli/_utils.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import contextlib
 import os
 import sys
 from collections.abc import Generator
-from functools import partial
 from typing import Any
 from xml.etree import ElementTree
 
@@ -14,12 +15,17 @@ else:  # pragma: no cover (<PY312)
 from gimli._constants import UnitStatus
 from gimli.errors import DatabaseNotFoundError
 
-out = partial(print, file=sys.stderr)
-err = partial(print, file=sys.stderr)
+
+def out(*args: Any, **kwds: Any) -> None:
+    print(*args, file=sys.stderr, **kwds)
+
+
+def err(*args: Any, **kwds: Any) -> None:
+    print(*args, file=sys.stderr, **kwds)
 
 
 @contextlib.contextmanager
-def suppress_stdout() -> Generator[None, None, None]:
+def suppress_stdout() -> Generator[None]:
     null_fds = [os.open(os.devnull, os.O_RDWR) for x in range(2)]
     # Save the actual stdout (1) and stderr (2) file descriptors.
     save_fds = [os.dup(1), os.dup(2)]

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -29,6 +29,16 @@ def test_no_op(capsys):
     assert capsys.readouterr().out == ""
 
 
+def test_verbose(tmpdir, capsys):
+    values = np.arange(12.0).reshape((3, 4))
+    with tmpdir.as_cwd():
+        np.savetxt("foobar.txt", values, delimiter=",")
+        assert main(["--verbose", "--from=m", "--to=km", "foobar.txt"]) == 0
+
+    last_line = capsys.readouterr().err.strip().splitlines()[-1]
+    assert last_line == "[info] reading foobar.txt"
+
+
 @pytest.mark.parametrize("shape", [(-1,), (-1, 1), (3, -1)])
 def test_from_file(tmpdir, shape, capsys):
     values = np.arange(12.0).reshape(shape)


### PR DESCRIPTION
I've removed the deprecated `FileType` argument type from *gimli*'s cli.