### PR TITLE
Suppress udunits error messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 - Removed deprecated ``FileType`` *argparse* types from the *cli*.
 - Added new api functions ``convert``, ``make_converter``, and ``get_unit_system``.
 - Added new *gimli* exceptions that map the *udunits* status codes.
+- Set the *udunits* error message handler to suppress error messages.
 
 ## 0.3.3 (2024-10-04)
 

--- a/src/gimli/_udunits2.pyx
+++ b/src/gimli/_udunits2.pyx
@@ -22,7 +22,6 @@ from gimli._constants import UnitEncoding
 from gimli._constants import UnitFormatting
 from gimli._constants import UnitStatus
 from gimli._utils import get_xml_path
-from gimli._utils import suppress_stdout
 from gimli.errors import GimliInternalError
 from gimli.errors import UnitOperationError
 from gimli.errors import exception_from_status
@@ -41,6 +40,9 @@ class UdunitsError(Exception):
     def __str__(self):
         return f"udunits error ({self.code})"
 
+cdef extern from "stdarg.h":
+    ctypedef struct va_list:
+        pass
 
 cdef extern from "udunits2.h":
     ctypedef struct ut_system:
@@ -51,6 +53,7 @@ cdef extern from "udunits2.h":
         pass
     ctypedef int ut_encoding;
     ctypedef int ut_status;
+    ctypedef int (*ut_error_message_handler)(const char* fmt, va_list args)
 
     const char* ut_get_path_xml(const char* path, ut_status* status)
     ut_unit* ut_get_unit_by_symbol(const ut_system* system, const char* symbol)
@@ -82,6 +85,9 @@ cdef extern from "udunits2.h":
 
     ut_status ut_get_status()
 
+    ut_error_message_handler ut_set_error_message_handler(ut_error_message_handler handler)
+    int ut_ignore(const char* fmt, va_list args)
+
 
 cdef class _UnitSystem:
     cdef ut_system* _unit_system
@@ -98,9 +104,8 @@ cdef class _UnitSystem:
         if self._filepath == NULL:
             raise MemoryError()
         strcpy(self._filepath, as_bytes)
-
-        with suppress_stdout():
-            self._unit_system = ut_read_xml(self._filepath)
+        ut_set_error_message_handler(ut_ignore)
+        self._unit_system = ut_read_xml(self._filepath)
 
         if self._unit_system == NULL:
             raise exception_from_status(ut_get_status(), filepath)
@@ -250,8 +255,7 @@ cdef class Unit:
         if not ut_are_convertible(self._unit, unit._unit):
             raise UnitOperationError(f"units are not convertable")
 
-        with suppress_stdout():
-            converter = ut_get_converter(self._unit, unit._unit)
+        converter = ut_get_converter(self._unit, unit._unit)
 
         if converter == NULL:
             raise exception_from_status(ut_get_status(), "unable to create converter")

--- a/src/gimli/_utils.py
+++ b/src/gimli/_utils.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import contextlib
 import os
 import sys
-from collections.abc import Generator
 from typing import Any
 from xml.etree import ElementTree
 
@@ -22,25 +20,6 @@ def out(*args: Any, **kwds: Any) -> None:
 
 def err(*args: Any, **kwds: Any) -> None:
     print(*args, file=sys.stderr, **kwds)
-
-
-@contextlib.contextmanager
-def suppress_stdout() -> Generator[None]:
-    null_fds = [os.open(os.devnull, os.O_RDWR) for x in range(2)]
-    # Save the actual stdout (1) and stderr (2) file descriptors.
-    save_fds = [os.dup(1), os.dup(2)]
-
-    os.dup2(null_fds[0], 1)
-    os.dup2(null_fds[1], 2)
-
-    yield
-
-    # Re-assign the real stdout/stderr back to (1) and (2)
-    os.dup2(save_fds[0], 1)
-    os.dup2(save_fds[1], 2)
-    # Close the null files
-    for fd in null_fds + save_fds:
-        os.close(fd)
 
 
 def get_xml_path(filepath: str | None = None) -> tuple[str, UnitStatus]:


### PR DESCRIPTION
The *udunits* library was printing error messages when loading it's database. These didn't seem like error messages but rather warnings that didn't affect things. *gimli* had been suppressing these messages with the `suppress_stdout` decorator but I've modified `UnitSystem` to now call the *udunits* `ut_set_error_message_handler` function and set the message handler to `ut_ignore`.