### PR TITLE
Fix the noxfile session that builds the vendored libraries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,15 +117,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install udunits2
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libudunits2-dev udunits-bin pkg-config
-
       - name: Coverage
         run: |
           pip install nox
-          nox -s coverage --force-pythons=${{ matrix.python-version }} --verbose
+          nox -s build-vendor coverage --force-pythons=${{ matrix.python-version }} --verbose -- dist/vendor
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
The *nox* session that built the vendored libraries was broken after the #41 and needed some cleaning up anyway. I've done that here.

Added new sessions: `build-vendor`, `build-expat`, and `build-udunits`. The `coverage` session now accepts a path to an installed *udunits*.