### PR TITLE
Move the units database into the api module

### DIFF
--- a/src/gimli/__init__.py
+++ b/src/gimli/__init__.py
@@ -1,8 +1,8 @@
 from gimli._api import convert
 from gimli._api import get_unit_system
 from gimli._api import make_converter
+from gimli._api import units
 from gimli._version import __version__
-from gimli.units import units
 
 __all__ = [
     "__version__",

--- a/src/gimli/_api.py
+++ b/src/gimli/_api.py
@@ -9,7 +9,6 @@ from numpy.typing import NDArray
 from gimli._system import UnitSystem
 from gimli._utils import get_xml_path
 
-
 _UNIT_SYSTEM_CACHE: dict[str, UnitSystem] = {}
 
 
@@ -170,3 +169,6 @@ class Converter:
 
 def _canonicalize_path(path: str) -> str:
     return os.path.normcase(os.path.abspath(os.path.normpath(path)))
+
+
+units = get_unit_system()

--- a/src/gimli/units.py
+++ b/src/gimli/units.py
@@ -1,3 +1,0 @@
-from gimli._api import get_unit_system
-
-units = get_unit_system()


### PR DESCRIPTION
The default unit system, `units`, was by itself in the `units.py` module. Apart from being a little disorganized, this was confusing—there was a `units` variable that was an instance of the default unit system, and there was also a `units` module.