### PR TITLE
Fix converter for non-affine unit transformations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@
 - Added new *gimli* exceptions that map the *udunits* status codes.
 - Set the *udunits* error message handler to suppress error messages.
 - Changed the minimum supported version to Python 3.11.
+- Added a new class, `UnitConverter`, that replaces `make_converter` and fixes an issue
+  it had with non-affine transformations.
 
 ## 0.3.3 (2024-10-04)
 

--- a/src/gimli/__init__.py
+++ b/src/gimli/__init__.py
@@ -1,13 +1,13 @@
+from gimli._api import UnitConverter
 from gimli._api import convert
 from gimli._api import get_unit_system
-from gimli._api import make_converter
 from gimli._api import units
 from gimli._version import __version__
 
 __all__ = [
     "__version__",
     "convert",
+    "UnitConverter",
     "get_unit_system",
-    "make_converter",
     "units",
 ]

--- a/src/gimli/_api.py
+++ b/src/gimli/_api.py
@@ -12,7 +12,7 @@ from gimli._utils import get_xml_path
 _UNIT_SYSTEM_CACHE: dict[str, UnitSystem] = {}
 
 
-def make_converter(src: str, dst: str, system: UnitSystem | None = None) -> Converter:
+class UnitConverter:
     """Create a callable converter between two units.
 
     Parameters
@@ -27,28 +27,67 @@ def make_converter(src: str, dst: str, system: UnitSystem | None = None) -> Conv
 
     Returns
     -------
-    converter: Converter
+    converter: UnitConverter
         A callable object that converts values from *src* to *dst*.
 
     Examples
     --------
-    >>> c = make_converter("degC", "K")
-    >>> c(0.0)
+    >>> convert = UnitConverter("degC", "K")
+    >>> convert(0.0)
     273.15
+
+    >>> convert = UnitConverter("miles / hr", "km / hour")
+    >>> convert(55)
+    88.51392
     """
-    if system is None:
-        _system = get_unit_system()
-    else:
-        _system = system
 
-    src_units = _system.Unit(src)
-    dst_units = _system.Unit(dst)
-    src_to_dst = src_units.to(dst_units)
+    def __init__(self, src: str, dst: str, system: UnitSystem | None = None) -> None:
+        self._system = get_unit_system() if system is None else system
 
-    offset = src_to_dst(0.0)
-    scale = src_to_dst(1.0) - offset
+        self._src_to_dst = self._system.Unit(src).to(self._system.Unit(dst))
 
-    return Converter(src, dst, scale=scale, offset=offset)
+        self._src = src
+        self._dst = dst
+
+    @property
+    def source(self) -> str:
+        return self._src
+
+    @property
+    def destination(self) -> str:
+        return self._dst
+
+    def __call__(self, values: ArrayLike) -> float | NDArray[np.floating]:
+        if np.isscalar(values):
+            return self._src_to_dst(values)
+        return self._src_to_dst(np.asarray(values))
+
+    def __repr__(self) -> str:
+        args = [repr(self.source), repr(self.destination)]
+        if self._system != get_unit_system():
+            args += [f"system=UnitSystem({self._system.database!r})"]
+        return f"UnitConverter({', '.join(args)})"
+
+    def inverse(self) -> UnitConverter:
+        """Create a converter that goes in the opposite direction.
+
+        Examples
+        --------
+        >>> a = UnitConverter("min / mile", "s / (400 m)")
+        >>> int(a(4.0))
+        59
+
+        >>> a = UnitConverter("mile", "m")
+        >>> a(4.0)
+        6437.376
+        >>> a.inverse()
+        UnitConverter('m', 'mile')
+
+        >>> b = a.inverse()
+        >>> b(a(4.0))
+        4.0
+        """
+        return UnitConverter(self.destination, self.source, system=self._system)
 
 
 def convert(
@@ -89,7 +128,7 @@ def convert(
     >>> convert([0.0, 1000.0], "m", "km")
     array([0., 1.])
     """
-    converter = make_converter(from_, to, system=system)
+    converter = UnitConverter(from_, to, system=system)
     return converter(values)
 
 
@@ -129,42 +168,6 @@ def get_unit_system(filepath: str | None = None) -> UnitSystem:
     if canonical_path not in _UNIT_SYSTEM_CACHE:
         _UNIT_SYSTEM_CACHE[canonical_path] = UnitSystem(canonical_path)
     return _UNIT_SYSTEM_CACHE[canonical_path]
-
-
-class Converter:
-    """Convert units."""
-
-    __slots__ = ("source", "destination", "scale", "offset")
-
-    def __init__(
-        self,
-        src: str,
-        dst: str,
-        *,
-        scale: float,
-        offset: float,
-    ) -> None:
-        self.source = src
-        self.destination = dst
-        self.scale = float(scale)
-        self.offset = float(offset)
-
-    def __call__(self, values: ArrayLike) -> float | NDArray:
-        """Convert values from source to destination units."""
-        if np.isscalar(values):
-            return self.scale * float(values) + self.offset
-
-        arr = np.asarray(values)
-        return arr * self.scale + self.offset
-
-    def __repr__(self) -> str:
-        args = (
-            repr(self.source),
-            repr(self.destination),
-            f"scale={self.scale!r}",
-            f"offset={self.offset!r}",
-        )
-        return f"Converter({', '.join(args)})"
 
 
 def _canonicalize_path(path: str) -> str:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1,11 +1,37 @@
 import pytest
 from numpy.testing import assert_almost_equal
 
-from gimli._api import Converter
+from gimli._api import UnitConverter
 from gimli._api import convert
 from gimli._api import get_unit_system
-from gimli._api import make_converter
 from gimli._system import UnitSystem
+
+
+def _setup_fake_database(path):
+    (path / "udunits2-fake.xml").write_text(
+        """\
+<?xml version="1.0" encoding="US-ASCII"?>
+<unit-system><import>udunits2-base.xml</import></unit-system>""",
+        encoding="utf-8",
+    )
+    (path / "udunits2-base.xml").write_text(
+        """\
+<?xml version="1.0" encoding="US-ASCII"?>
+<unit-system>
+    <unit>
+        <base/>
+        <name><singular>meter</singular></name>
+        <symbol>m</symbol>
+    </unit>
+    <unit>
+        <base/>
+        <name><singular>kilogram</singular></name>
+        <symbol>kg</symbol>
+    </unit>
+</unit-system>""",
+        encoding="utf-8",
+    )
+    return str(path / "udunits2-fake.xml")
 
 
 def test_convert():
@@ -19,8 +45,8 @@ def test_convert():
     (("m", "km"), ("km", "m"), ("nm", "parsec"), ("degC", "degF"), ("degK", "degC")),
 )
 def test_convert_repr(unit_a, unit_b):
-    converter_a = make_converter(unit_a, unit_b)
-    converter_b = eval(repr(converter_a), {"Converter": Converter})
+    converter_a = UnitConverter(unit_a, unit_b)
+    converter_b = eval(repr(converter_a))
 
     assert converter_a(53.0) == pytest.approx(converter_b(53.0))
 
@@ -30,8 +56,8 @@ def test_convert_round_trip(value):
     assert convert(convert(value, "km", "m"), "m", "km") == pytest.approx(value)
 
 
-def test_make_converter():
-    c = make_converter("m", "km")
+def test_converter():
+    c = UnitConverter("m", "km")
     assert c(10.0) == pytest.approx(0.01)
 
 
@@ -40,15 +66,26 @@ def test_make_converter():
     "unit_a, unit_b",
     (("m", "km"), ("km", "m"), ("nm", "parsec"), ("degC", "degF"), ("degK", "degC")),
 )
-def test_make_converter_round_trip(value, unit_a, unit_b):
-    m_to_km = make_converter(unit_a, unit_b)
-    km_to_m = make_converter(unit_b, unit_a)
+def test_converter_round_trip(value, unit_a, unit_b):
+    m_to_km = UnitConverter(unit_a, unit_b)
+    km_to_m = UnitConverter(unit_b, unit_a)
     assert_almost_equal(km_to_m(m_to_km(value)), value)
 
 
-def test_make_converter_with_unit_system():
-    m_to_km = make_converter("m", "km", system=UnitSystem())
-    assert m_to_km("1000.0") == pytest.approx(1.0)
+@pytest.mark.parametrize("value", (53.0, 0.0, -1.0, [4, 6]))
+@pytest.mark.parametrize(
+    "unit_a, unit_b",
+    (("m", "km"), ("km", "m"), ("nm", "parsec"), ("degC", "degF"), ("degK", "degC")),
+)
+def test_converter_inverse(value, unit_a, unit_b):
+    m_to_km = UnitConverter(unit_a, unit_b)
+    km_to_m = m_to_km.inverse()
+    assert_almost_equal(km_to_m(m_to_km(value)), value)
+
+
+def test_converter_with_default_unit_system():
+    m_to_km = UnitConverter("m", "km", system=UnitSystem())
+    assert m_to_km(1000.0) == pytest.approx(1.0)
 
 
 def test_get_unit_system():
@@ -60,3 +97,18 @@ def test_get_unit_system_singleton():
     system_a = get_unit_system()
     system_b = get_unit_system()
     assert system_a is system_b
+
+
+def test_converter_with_unit_system(tmp_path):
+    system = UnitSystem(_setup_fake_database(tmp_path))
+
+    converter_a = UnitConverter("m / kg", "kg / m", system=system)
+    assert converter_a(53) == pytest.approx(1 / 53)
+    assert (
+        repr(converter_a)
+        == f"UnitConverter('m / kg', 'kg / m', system=UnitSystem({system.database!r}))"
+    )
+
+    converter_b = eval(repr(converter_a))
+
+    assert converter_a(-2) == pytest.approx(converter_b(-2))


### PR DESCRIPTION
I've removed `make_converter` and added a `UnitConverter` class as a replacement. The new converter uses the *udunits* converter. The old converter calculated a scale and offset for the transformation and then used *numpy*. That worked great for affine transformations link `m -> km` but not for conversions like `min / mile -> miles / hour`.