### PR TITLE
Rename convert to convert_units

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 - Changed the minimum supported version to Python 3.11.
 - Added a new class, `UnitConverter`, that replaces `make_converter` and fixes an issue
   it had with non-affine transformations.
+- Renamed the `gimli.convert` function to `gimli.convert_units`.
 
 ## 0.3.3 (2024-10-04)
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ which can be found in the `extern` folder of this repository).
 Use `gimli.convert` to convert scalars or arrays between unit strings:
 
 ```python
->>> from gimli import convert
+>>> from gimli import convert_units
 
->>> convert(10.0, "N", "lb.ft/s2")
+>>> convert_units(10.0, "N", "lb.ft/s2")
 72.33013851209893
->>> convert([0.0, 250.0, 1000.0], "N", "lb*ft/s^2")
+>>> convert_units([0.0, 250.0, 1000.0], "N", "lb*ft/s^2")
 array([   0.        , 1808.2534628 , 7233.01385121])
 ```
 
@@ -71,9 +71,9 @@ array([   0.        , 1808.2534628 , 7233.01385121])
 If you will apply the same conversion many times, build a converter once:
 
 ```python
->>> from gimli import make_converter
+>>> from gimli import UnitConverter
 
->>> m_to_ft = make_converter("m", "ft")
+>>> m_to_ft = UnitConverter("m", "ft")
 >>> m_to_ft([0.0, 1.0, 2.0])
 array([0.        , 3.2808399 , 6.56167979])
 >>> m_to_ft(3.0)

--- a/src/gimli/__init__.py
+++ b/src/gimli/__init__.py
@@ -1,13 +1,13 @@
 from gimli._api import UnitConverter
-from gimli._api import convert
+from gimli._api import convert_units
 from gimli._api import get_unit_system
 from gimli._api import units
 from gimli._version import __version__
 
 __all__ = [
     "__version__",
-    "convert",
     "UnitConverter",
+    "convert_units",
     "get_unit_system",
     "units",
 ]

--- a/src/gimli/_api.py
+++ b/src/gimli/_api.py
@@ -90,7 +90,7 @@ class UnitConverter:
         return UnitConverter(self.destination, self.source, system=self._system)
 
 
-def convert(
+def convert_units(
     values: ArrayLike, from_: str, to: str, system: UnitSystem | None = None
 ) -> float | NDArray[np.floating]:
     """Convert values from one unit to another.
@@ -120,12 +120,12 @@ def convert(
     --------
     Convert a scalar:
 
-    >>> convert(10.0, "m", "ft")
+    >>> convert_units(10.0, "m", "ft")
     32.80839895013123
 
     Convert an array:
 
-    >>> convert([0.0, 1000.0], "m", "km")
+    >>> convert_units([0.0, 1000.0], "m", "km")
     array([0., 1.])
     """
     converter = UnitConverter(from_, to, system=system)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2,7 +2,7 @@ import pytest
 from numpy.testing import assert_almost_equal
 
 from gimli._api import UnitConverter
-from gimli._api import convert
+from gimli._api import convert_units
 from gimli._api import get_unit_system
 from gimli._system import UnitSystem
 
@@ -34,9 +34,9 @@ def _setup_fake_database(path):
     return str(path / "udunits2-fake.xml")
 
 
-def test_convert():
+def test_convert_units():
     expected = 0.01
-    actual = convert(10.0, "m", "km")
+    actual = convert_units(10.0, "m", "km")
     assert actual == pytest.approx(expected)
 
 
@@ -53,7 +53,9 @@ def test_convert_repr(unit_a, unit_b):
 
 @pytest.mark.parametrize("value", (53.0, 0.0, -1.0, [4, 6]))
 def test_convert_round_trip(value):
-    assert convert(convert(value, "km", "m"), "m", "km") == pytest.approx(value)
+    assert convert_units(convert_units(value, "km", "m"), "m", "km") == pytest.approx(
+        value
+    )
 
 
 def test_converter():


### PR DESCRIPTION
I've renamed the `convert` function to the more descriptive `convert_units`.