### PR TITLE
Add a note to udunits errors

### DIFF
--- a/src/gimli/errors.py
+++ b/src/gimli/errors.py
@@ -19,10 +19,13 @@ def exception_from_status(
     if exc_type is None:
         raise GimliInternalError(f"unknown udunits status ({status!r})")
 
+    desc = STATUS_MESSAGE[status]
     if message is None:
-        return exc_type(STATUS_MESSAGE[status])
+        return exc_type(f"UDUNITS-2 error: {desc}")
     else:
-        return exc_type(message)
+        exc = exc_type(message)
+        exc.add_note(f"UDUNITS-2 status: {status} - {desc}")
+        return exc
 
 
 class GimliError(Exception):


### PR DESCRIPTION
I've modified `exception_from_status` to use `add_note` to add the *udunits*'s status message to exceptions.