### PR TITLE
Add pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,8 @@
+# Checklist
+
+- [ ] Update version `src/gimli/_version.py`.
+- [ ] Update version in the `CHANGES.md`.
+- [ ] Proofread and edit `CHANGES.md`.
+- [ ] Test publish to *testpypi* and install from *testpypi*.
+- [ ] Create tag `vX.Y.Z`.
+- [ ] Publish to *pypi* 🚀.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+> Please rebase onto `main` before requesting review.
+> We prefer a linear history (no merge commits). Thanks! 🙏
+
+# Summary
+
+<!-- What does this PR do? Keep it short and concrete. -->
+
+## Checklist
+
+- [ ] Docstrings/docs updated
+- [ ] Changelog entry added
+- [ ] Commit history is clean and logically organized


### PR DESCRIPTION
I've added two now pull request templates. The fist, which is the default, is for fixes, updates, etc. The second is for creating new releases. I've intentionally kept both short and sweet.