### PR TITLE
Add a contributing doc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/config.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Contributing Guide
+    url: https://github.com/mcflugen/gimli/blob/main/CONTRIBUTING.md
+    about: Please review contribution guidelines before submitting a PR.
+
+  - name: Documentation
+    url: https://github.com/mcflugen/gimli/blob/main/README.md
+    about: Check the documentation before opening a PR.

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -9,4 +9,4 @@
 
 - [ ] Docstrings/docs updated
 - [ ] Changelog entry added
-- [ ] Commit history is clean and logically organized
+- [ ] Commit history cleaned up (no WIP/fixup commits)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 - Added a new class, `UnitConverter`, that replaces `make_converter` and fixes an issue
   it had with non-affine transformations.
 - Renamed the `gimli.convert` function to `gimli.convert_units`.
+- Added a CONTRIBUTING doc and pull request templates.
 
 ## 0.3.3 (2024-10-04)
 

--- a/CONTRUBUTING.md
+++ b/CONTRUBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to gimli
+
+Thank you for your interest in contributing to gimli. 🙏
+
+## Workflow
+
+- Create a feature branch from `main`.
+- Rebase onto `main` before requesting review (no merge commits).
+- Please squash or reorder commits before review if the history contains WIP or fixup commits.
+- Ensure all tests pass and CI is green.
+
+## Pull Requests
+
+- Use the default PR template for normal changes.
+- Use the release template only when preparing a release.
+- Add or update tests for bug fixes and new features.
+- Update `CHANGES.md` for user-facing changes.
+
+## Style
+
+- Follow existing code style and structure.
+- Keep changes focused and minimal.
+- Write clear commit messages.
+
+## Reporting Issues
+
+Please include:
+
+- A minimal reproducible example
+- Expected behavior
+- Actual behavior
+- Python version and platform


### PR DESCRIPTION
> Please rebase onto `main` before requesting review.
> We prefer a linear history (no merge commits). Thanks! 🙏

# Summary

I've moved the default pull request template into the `PULL_REQUEST_TEMPLATE` folder to allow a user to choose the pr type through the GitHub UI. Leaving it up to the user to construct a proper URL for a release PR was a bad idea.

I've added a `config.yml` in `PULL_REQUEST_TEMPLATE` that disallows empty templates and points to the README and CONTRIBUTING docs (which I also added).

## Checklist

- [x] Docstrings/docs updated
- [x] Changelog entry added
- [x] Commit history is clean and logically organized
