### PR TITLE
Use importlib.metadata for version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,6 +1,6 @@
 # Checklist
 
-- [ ] Update version `src/gimli/_version.py`.
+- [ ] Update version `pyproject.toml`
 - [ ] Update version in the `CHANGES.md`.
 - [ ] Proofread and edit `CHANGES.md`.
 - [ ] Test publish to *testpypi* and install from *testpypi*.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@
   it had with non-affine transformations.
 - Renamed the `gimli.convert` function to `gimli.convert_units`.
 - Added a CONTRIBUTING doc and pull request templates.
+- Added the canonical *gimli* version to `pyproject.toml` and use `importlib.metadata`
+  in `_version.py` to set the version.
 
 ## 0.3.3 (2024-10-04)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "gimli.units"
+version = "0.3.4"
 requires-python = ">=3.11"
 description = "An object-oriented Python interface to udunits"
 license = "MIT"
@@ -33,10 +34,7 @@ dependencies = [
     "importlib-resources; python_version < '3.12'",
     "numpy",
 ]
-dynamic = [
-    "readme",
-    "version",
-]
+dynamic = ["readme"]
 
 [project.optional-dependencies]
 dev = [

--- a/src/gimli/_version.py
+++ b/src/gimli/_version.py
@@ -1,1 +1,9 @@
-__version__ = "0.3.4.dev0"
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version
+
+try:
+    __version__ = version("gimli")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"


### PR DESCRIPTION
> Please rebase onto `main` before requesting review.
> We prefer a linear history (no merge commits). Thanks! 🙏

# Summary

I've moved the canonical *gimli* version into `pyproject.toml` and now use `imporlib.metadata` in `_version.py` to get the version. I think it's just a little easier to maintain the version in `pyproject.toml`.

## Checklist

- [x] Docstrings/docs updated
- [x] Changelog entry added
- [x] Commit history cleaned up (no WIP/fixup commits)
